### PR TITLE
HotFix: Fix the Docker image build step

### DIFF
--- a/.github/workflows/deploy-project.yaml
+++ b/.github/workflows/deploy-project.yaml
@@ -139,8 +139,7 @@ jobs:
     # Defines that test-project job must finish successfully first, before this one can run
     needs: test-project
     # The if statement limits it to run only if action was triggered on main branch or one of the tags
-    # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') 
-    # TODO: Re-enable if statement above after testing docker build 
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     runs-on: self-hosted-linux
     # Outputs allows a job to output values that can be picked up by _downstream_ jobs that _depend_ on this job
     outputs:

--- a/.github/workflows/deploy-project.yaml
+++ b/.github/workflows/deploy-project.yaml
@@ -139,7 +139,8 @@ jobs:
     # Defines that test-project job must finish successfully first, before this one can run
     needs: test-project
     # The if statement limits it to run only if action was triggered on main branch or one of the tags
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') 
+    # TODO: Re-enable if statement above after testing docker build 
     runs-on: self-hosted-linux
     # Outputs allows a job to output values that can be picked up by _downstream_ jobs that _depend_ on this job
     outputs:
@@ -204,6 +205,8 @@ jobs:
           push: true
           # Build context, makes the build process use actual files in the runner instead of using files from GitHub
           context: .
+          # Override the path to the Dockerfile, since this project has it in the docker folder
+          file: "{context}/docker/Dockerfile"
           # Set tags for the image using output from the meta step
           tags: ${{ steps.meta.outputs.tags }}
           # Set labels for the image using output from the meta step

--- a/.github/workflows/deploy-project.yaml
+++ b/.github/workflows/deploy-project.yaml
@@ -206,7 +206,7 @@ jobs:
           # Build context, makes the build process use actual files in the runner instead of using files from GitHub
           context: .
           # Override the path to the Dockerfile, since this project has it in the docker folder
-          file: "{context}/docker/Dockerfile"
+          file: ./docker/Dockerfile
           # Set tags for the image using output from the meta step
           tags: ${{ steps.meta.outputs.tags }}
           # Set labels for the image using output from the meta step


### PR DESCRIPTION
Add the missing file input to the `docker/build-push-action@v5` action which is needed after moving the `Dockerfile` to the `docker` folder