### PR TITLE
MLT-0028 fix error in product creation

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/product/controller/ProductController.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/product/controller/ProductController.kt
@@ -22,7 +22,9 @@ class ProductController(val productService: ProductService) {
         summary = "Register a product in the storage system",
         description =
             "Register data about the product in Hermes WLS and appropriate storage system, " +
-                "so that the physical product can be placed in the physical storage."
+                "so that the physical product can be placed in the physical storage. " +
+                "NOTE: When registering new product quantity and location are set to default values (0.0 and null). " +
+                "Hence you should not provide these values in the payload, or at least know they will be overwritten."
     )
     @ApiResponses(
         value = [

--- a/src/main/kotlin/no/nb/mlt/wls/product/payloads/ApiProductPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/product/payloads/ApiProductPayload.kt
@@ -1,6 +1,7 @@
 package no.nb.mlt.wls.product.payloads
 
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY
 import no.nb.mlt.wls.core.data.Environment
 import no.nb.mlt.wls.core.data.HostName
 import no.nb.mlt.wls.core.data.Owner
@@ -66,6 +67,7 @@ data class ApiProductPayload(
     @Schema(
         description = "Where the product is located, e.g. SYNQ_WAREHOUSE, AUTOSTORE, KARDEX, etc.",
         examples = ["SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"],
+        accessMode = READ_ONLY,
         required = false
     )
     val location: String?,
@@ -74,6 +76,7 @@ data class ApiProductPayload(
             "Quantity on hand of the product, this denotes if the product is in storage or not. " +
                 "If the product is in storage then quantity is 1.0, if it's not in storage then quantity is 0.0.",
         examples = [ "0.0", "1.0"],
+        accessMode = READ_ONLY,
         required = false
     )
     val quantity: Double?

--- a/src/main/kotlin/no/nb/mlt/wls/product/service/ProductService.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/product/service/ProductService.kt
@@ -27,7 +27,11 @@ class ProductService(val db: ProductRepository, val synqService: SynqService) {
             return ResponseEntity.ok(existingProduct.toApiPayload())
         }
 
-        val product = payload.toProduct()
+        // Convert payload to product, but set quantity and location to default values in case they are given
+        // We don't want to use values from the payload, as the product should not be in the storage system yet
+        // Hence its quantity should be 0 and location should be null
+        // Not done in the mapping function as we want it to be explicit for clarity
+        val product = payload.toProduct().copy(quantity = 0.0, location = null)
 
         // Product service should create the product in the storage system, and return error message if it fails
         if (synqService.createProduct(product.toSynqPayload()).statusCode.isSameCodeAs(HttpStatus.OK)) {


### PR DESCRIPTION
Change how we handle the location and quantity in the product endpoint. We used to receive them as is and forward them to the database and other places. That does not make sense as the catalogue does not decide the quantity nor the location. Now the endpoint ignores them and overrides these fields with default values.
The swagger doc reflects the change by making those two fields read only.