### PR TITLE
MLT-0022 Define datastructure for orders

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/core/data/synq/SynqOwner.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/core/data/synq/SynqOwner.kt
@@ -1,0 +1,17 @@
+package no.nb.mlt.wls.core.data.synq
+
+import no.nb.mlt.wls.core.data.Owner
+
+enum class SynqOwner {
+    NB
+}
+
+fun SynqOwner.toOwner(): Owner =
+    when (this) {
+        SynqOwner.NB -> Owner.NB
+    }
+
+fun Owner.toSynqOwner(): SynqOwner =
+    when (this) {
+        Owner.NB -> SynqOwner.NB
+    }

--- a/src/main/kotlin/no/nb/mlt/wls/order/model/Order.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/model/Order.kt
@@ -1,5 +1,7 @@
 package no.nb.mlt.wls.order.model
 
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY
 import no.nb.mlt.wls.core.data.HostName
 import no.nb.mlt.wls.core.data.Owner
 import org.springframework.data.mongodb.core.mapping.Document
@@ -16,17 +18,73 @@ data class Order(
     val callbackUrl: String
 )
 
+@Schema(
+    description = "Represents an order/product line in an order, containing information about ordered product.",
+    example = """
+    {
+      "hostId": "mlt-12345",
+      "status": "NOT_STARTED"
+    }
+    """
+)
 data class ProductLine(
+    @Schema(
+        description = "Product ID from the host system.",
+        example = "mlt-12345"
+    )
     val hostId: String,
-    val status: OrderStatus?
+    @Schema(
+        description = "Current status of the order line.",
+        examples = [ "NOT_STARTED", "PICKED", "FAILED" ],
+        defaultValue = "NOT_STARTED",
+        accessMode = READ_ONLY
+    )
+    val status: OrderLineStatus?
 )
 
+@Schema(
+    description = "Information about order recipient.",
+    example = """
+    {
+      "name": "Doug Dimmadome",
+      "location": "Doug Dimmadome's office in the Dimmsdale Dimmadome",
+      "address": "Dimmsdale Dimmadome",
+      "city": "Dimmsdale",
+      "postalCode": "69-420",
+      "phoneNum": "+47 666 69 420"
+    }
+    """
+)
 data class OrderReceiver(
+    @Schema(
+        description = "Name of the recipient.",
+        example = "Doug Dimmadome"
+    )
     val name: String,
+    @Schema(
+        description = "Recipient's location, e.g. building, room, etc.",
+        example = "Doug Dimmadome's office in the Dimmsdale Dimmadome"
+    )
     val location: String,
+    @Schema(
+        description = "Recipient's address, e.g. street address, PO box, etc.",
+        example = "Dimmsdale Dimmadome"
+    )
     val address: String?,
+    @Schema(
+        description = "Recipient's city.",
+        example = "Dimmsdale"
+    )
     val city: String?,
+    @Schema(
+        description = "Recipient's postal code.",
+        example = "69-420"
+    )
     val postalCode: String?,
+    @Schema(
+        description = "Recipient's phone number, should contain country code, especially if it's a foreign number.",
+        example = "+47 666 69 420"
+    )
     val phoneNumber: String?
 )
 
@@ -35,6 +93,16 @@ enum class OrderStatus(private val status: String) {
     IN_PROGRESS("In progress"),
     COMPLETED("Completed"),
     DELETED("Deleted");
+
+    override fun toString(): String {
+        return status
+    }
+}
+
+enum class OrderLineStatus(private val status: String) {
+    NOT_STARTED("Not started"),
+    PICKED("Picked"),
+    FAILED("Failed");
 
     override fun toString(): String {
         return status

--- a/src/main/kotlin/no/nb/mlt/wls/order/model/Order.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/model/Order.kt
@@ -1,0 +1,51 @@
+package no.nb.mlt.wls.order.model
+
+import no.nb.mlt.wls.core.data.HostName
+import no.nb.mlt.wls.core.data.Owner
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document(collection = "orders")
+data class Order (
+    val hostName: HostName,
+    val hostOrderId: String,
+    val status: OrderStatus,
+    val productLine: List<ProductLine>,
+    val orderType: OrderType,
+    val receiver: OrderReceiver,
+    val callbackUrl: String,
+    val owner: Owner
+)
+
+data class ProductLine (
+    val hostId: String,
+    val status: OrderStatus?
+)
+
+data class OrderReceiver (
+    val name: String,
+    val location: String,
+    val address: String?,
+    val city: String?,
+    val postalCode: String?,
+    val phoneNumber: String?
+)
+
+enum class OrderStatus(private val status: String) {
+    NOT_STARTED("Not started"),
+    IN_PROGRESS("In progress"),
+    COMPLETED("Completed"),
+    DELETED("Deleted");
+
+    override fun toString(): String {
+        return status
+    }
+}
+
+enum class OrderType(private val type: String) {
+    LOAN("Loan"),
+    DIGITIZATION("Digitization"),;
+
+    override fun toString(): String {
+        return type
+    }
+}

--- a/src/main/kotlin/no/nb/mlt/wls/order/model/Order.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/model/Order.kt
@@ -5,23 +5,23 @@ import no.nb.mlt.wls.core.data.Owner
 import org.springframework.data.mongodb.core.mapping.Document
 
 @Document(collection = "orders")
-data class Order (
+data class Order(
     val hostName: HostName,
     val hostOrderId: String,
     val status: OrderStatus,
     val productLine: List<ProductLine>,
     val orderType: OrderType,
+    val owner: Owner?,
     val receiver: OrderReceiver,
-    val callbackUrl: String,
-    val owner: Owner
+    val callbackUrl: String
 )
 
-data class ProductLine (
+data class ProductLine(
     val hostId: String,
     val status: OrderStatus?
 )
 
-data class OrderReceiver (
+data class OrderReceiver(
     val name: String,
     val location: String,
     val address: String?,
@@ -43,7 +43,7 @@ enum class OrderStatus(private val status: String) {
 
 enum class OrderType(private val type: String) {
     LOAN("Loan"),
-    DIGITIZATION("Digitization"),;
+    DIGITIZATION("Digitization") ;
 
     override fun toString(): String {
         return type

--- a/src/main/kotlin/no/nb/mlt/wls/order/payloads/ApiOrderPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/payloads/ApiOrderPayload.kt
@@ -1,0 +1,44 @@
+package no.nb.mlt.wls.order.payloads
+
+import no.nb.mlt.wls.core.data.HostName
+import no.nb.mlt.wls.core.data.Owner
+import no.nb.mlt.wls.order.model.Order
+import no.nb.mlt.wls.order.model.OrderReceiver
+import no.nb.mlt.wls.order.model.OrderStatus
+import no.nb.mlt.wls.order.model.OrderType
+import no.nb.mlt.wls.order.model.ProductLine
+
+data class ApiOrderPayload(
+    val hostName: HostName,
+    val hostOrderId: String,
+    val status: OrderStatus?,
+    val productLine: List<ProductLine>,
+    val orderType: OrderType,
+    val owner: Owner?,
+    val receiver: OrderReceiver,
+    val callbackUrl: String
+)
+
+fun ApiOrderPayload.toOrder() =
+    Order(
+        hostName = hostName,
+        hostOrderId = hostOrderId,
+        status = status ?: OrderStatus.NOT_STARTED,
+        productLine = productLine,
+        orderType = orderType,
+        owner = owner,
+        receiver = receiver,
+        callbackUrl = callbackUrl
+    )
+
+fun Order.toApiOrderPayload() =
+    ApiOrderPayload(
+        hostName = hostName,
+        hostOrderId = hostOrderId,
+        status = status,
+        productLine = productLine,
+        orderType = orderType,
+        owner = owner,
+        receiver = receiver,
+        callbackUrl = callbackUrl
+    )

--- a/src/main/kotlin/no/nb/mlt/wls/order/payloads/ApiOrderPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/payloads/ApiOrderPayload.kt
@@ -1,5 +1,7 @@
 package no.nb.mlt.wls.order.payloads
 
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY
 import no.nb.mlt.wls.core.data.HostName
 import no.nb.mlt.wls.core.data.Owner
 import no.nb.mlt.wls.order.model.Order
@@ -8,14 +10,81 @@ import no.nb.mlt.wls.order.model.OrderStatus
 import no.nb.mlt.wls.order.model.OrderType
 import no.nb.mlt.wls.order.model.ProductLine
 
+@Schema(
+    description = "Payload for creating and editing an order in Hermes WLS, and appropriate storage system(s).",
+    example = """
+    {
+      "orderId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "hostName": "AXIELL",
+      "hostOrderId": "mlt-12345-order",
+      "status": "NOT_STARTED",
+      "productLine": [
+        {
+          "hostId": "mlt-12345",
+          "status": "NOT_STARTED"
+        }
+      ],
+      "orderType": "LOAN",
+      "owner": "NB",
+      "receiver": {
+        "name": "Doug Dimmadome",
+        "location": "Doug Dimmadome's office in the Dimmsdale Dimmadome",
+        "address": "Dimmsdale Dimmadome",
+        "city": "Dimmsdale",
+        "postalCode": "69-420",
+        "phoneNum": "+47 666 69 420"
+      },
+      "callbackUrl": "https://example.com/send/callback/here"
+    }
+    """
+)
 data class ApiOrderPayload(
+    @Schema(
+        description = "Order ID in the database(?)",
+        example = "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        accessMode = READ_ONLY
+    )
+    // TODO: I don't see why we need this, but it was in the mock API
+    val orderId: String,
+    @Schema(
+        description = "Name of the host system which made the order.",
+        examples = [ "AXIELL", "ALMA", "ASTA", "BIBLIOFIL" ]
+    )
     val hostName: HostName,
+    @Schema(
+        description = "Order ID from the host system which made the order.",
+        example = "mlt-12345-order"
+    )
     val hostOrderId: String,
+    @Schema(
+        description = "Current status of the order as a whole.",
+        examples = [ "NOT_STARTED", "IN_PROGRESS", "COMPLETED", "DELETED" ]
+    )
     val status: OrderStatus?,
+    @Schema(
+        description = "List of products in the order, also called order lines, or product lines.",
+        accessMode = READ_ONLY
+    )
     val productLine: List<ProductLine>,
+    @Schema(
+        description = "Describes what type of order this is",
+        examples = [ "LOAN", "DIGITIZATION" ]
+    )
     val orderType: OrderType,
+    @Schema(
+        description = "Who's the owner of the material in the order.",
+        examples = [ "NB", "ARKIVVERKET" ],
+        accessMode = READ_ONLY
+    )
     val owner: Owner?,
+    @Schema(
+        description = "Who's the receiver of the material in the order."
+    )
     val receiver: OrderReceiver,
+    @Schema(
+        description = "URL to send a callback to when the order is completed.",
+        example = "https://example.com/send/callback/here"
+    )
     val callbackUrl: String
 )
 
@@ -33,6 +102,7 @@ fun ApiOrderPayload.toOrder() =
 
 fun Order.toApiOrderPayload() =
     ApiOrderPayload(
+        orderId = hostOrderId,
         hostName = hostName,
         hostOrderId = hostOrderId,
         status = status,

--- a/src/main/kotlin/no/nb/mlt/wls/order/payloads/ApiOrderPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/payloads/ApiOrderPayload.kt
@@ -39,12 +39,12 @@ import no.nb.mlt.wls.order.model.ProductLine
     """
 )
 data class ApiOrderPayload(
+    // TODO: I don't see why we need this, but it was in the mock API
     @Schema(
         description = "Order ID in the database(?)",
         example = "3fa85f64-5717-4562-b3fc-2c963f66afa6",
         accessMode = READ_ONLY
     )
-    // TODO: I don't see why we need this, but it was in the mock API
     val orderId: String,
     @Schema(
         description = "Name of the host system which made the order.",

--- a/src/main/kotlin/no/nb/mlt/wls/product/payloads/ApiProductPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/product/payloads/ApiProductPayload.kt
@@ -11,15 +11,15 @@ import no.nb.mlt.wls.product.model.Product
 @Schema(
     description = "Payload for registering a product in Hermes WLS, and appropriate storage system for the product.",
     example = """
-        {
-            "hostId": "mlt-12345",
-            "hostName": "AXIELL",
-            "description": "Tyven, tyven skal du hete",
-            "productCategory": "BOOK",
-            "preferredEnvironment": "NONE",
-            "packaging": "NONE",
-            "owner": "NB"
-        }
+    {
+      "hostId": "mlt-12345",
+      "hostName": "AXIELL",
+      "description": "Tyven, tyven skal du hete",
+      "productCategory": "BOOK",
+      "preferredEnvironment": "NONE",
+      "packaging": "NONE",
+      "owner": "NB"
+    }
     """
 )
 data class ApiProductPayload(

--- a/src/main/kotlin/no/nb/mlt/wls/product/payloads/SynqProductPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/product/payloads/SynqProductPayload.kt
@@ -2,11 +2,11 @@ package no.nb.mlt.wls.product.payloads
 
 import no.nb.mlt.wls.core.data.Environment
 import no.nb.mlt.wls.core.data.HostName
-import no.nb.mlt.wls.core.data.Owner
 import no.nb.mlt.wls.core.data.Packaging
+import no.nb.mlt.wls.core.data.synq.SynqOwner
+import no.nb.mlt.wls.core.data.synq.toOwner
+import no.nb.mlt.wls.core.data.synq.toSynqOwner
 import no.nb.mlt.wls.product.model.Product
-import no.nb.mlt.wls.product.payloads.SynqProductPayload.SynqOwner
-import no.nb.mlt.wls.product.payloads.SynqProductPayload.SynqOwner.NB
 import no.nb.mlt.wls.product.payloads.SynqProductPayload.SynqPackaging
 import no.nb.mlt.wls.product.payloads.SynqProductPayload.SynqPackaging.ESK
 import no.nb.mlt.wls.product.payloads.SynqProductPayload.SynqPackaging.OBJ
@@ -26,13 +26,9 @@ data class SynqProductPayload(
         ESK
     }
 
-    enum class SynqOwner {
-        NB
-    }
+    data class Barcode(val barcodeId: String)
 
-    class Barcode(val barcodeId: String)
-
-    class ProductUom(val uomId: SynqPackaging)
+    data class ProductUom(val uomId: SynqPackaging)
 }
 
 // unused
@@ -65,16 +61,6 @@ fun SynqPackaging.toPackaging(): Packaging =
     when (this) {
         OBJ -> Packaging.NONE
         ESK -> Packaging.BOX
-    }
-
-fun SynqOwner.toOwner(): Owner =
-    when (this) {
-        NB -> Owner.NB
-    }
-
-fun Owner.toSynqOwner(): SynqOwner =
-    when (this) {
-        Owner.NB -> NB
     }
 
 fun Packaging.toSynqPackaging(): SynqPackaging =


### PR DESCRIPTION
This PR introduces the draft of data structures which will represent orders in Hermes MLT, this includes both the main model class Order which will be stored in our database as well as the payload classes for API and SynQ.

There are quite a few questions and things we need to discuss in the team (and perchance outside the team) about some things related to the order. For more info see the code and Jira task