### PR TITLE
MLT-0032 Tests for OrderService

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/order/repository/OrderRepository.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/repository/OrderRepository.kt
@@ -8,7 +8,7 @@ import reactor.core.publisher.Mono
 
 @Repository
 interface OrderRepository : ReactiveMongoRepository<Order, String> {
-    fun getByHostNameAndHostOrderId(
+    fun findByHostNameAndHostOrderId(
         hostName: HostName,
         hostOrderId: String
     ): Mono<Order>

--- a/src/main/kotlin/no/nb/mlt/wls/order/service/OrderService.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/service/OrderService.kt
@@ -66,7 +66,7 @@ class OrderService(val db: OrderRepository, val synqService: SynqOrderService) {
             throw ServerWebInputException("The order's hostOrderId is required, and can not be blank")
         }
         if (payload.productLine.isEmpty()) {
-            throw ServerWebInputException("The order does not contain any product lines, and is therefore invalid")
+            throw ServerWebInputException("The order must contain product lines")
         }
     }
 }

--- a/src/main/kotlin/no/nb/mlt/wls/order/service/OrderService.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/service/OrderService.kt
@@ -24,7 +24,7 @@ class OrderService(val db: OrderRepository, val synqService: SynqOrderService) {
         throwIfInvalidPayload(payload)
 
         val existingOrder =
-            db.getByHostNameAndHostOrderId(payload.hostName, payload.orderId)
+            db.findByHostNameAndHostOrderId(payload.hostName, payload.orderId)
                 .timeout(Duration.ofSeconds(8))
                 .onErrorMap(TimeoutException::class.java) {
                     logger.error(it) {

--- a/src/main/kotlin/no/nb/mlt/wls/order/service/OrderService.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/service/OrderService.kt
@@ -38,7 +38,12 @@ class OrderService(val db: OrderRepository, val synqService: SynqOrderService) {
             return ResponseEntity.badRequest().build()
         }
 
-        synqService.createOrder(payload.toOrder().toSynqPayload())
+        // Handle any edge-cases
+        val synqResponse = synqService.createOrder(payload.toOrder().toSynqPayload())
+        if (!synqResponse.statusCode.isSameCodeAs(HttpStatus.CREATED)) {
+            throw ServerErrorException("Unexpected error with SynQ", null)
+        }
+
         // Return what the database saved, as it could contain changes
         val order =
             db.save(payload.toOrder())

--- a/src/main/kotlin/no/nb/mlt/wls/order/service/OrderService.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/service/OrderService.kt
@@ -38,8 +38,9 @@ class OrderService(val db: OrderRepository, val synqService: SynqOrderService) {
             return ResponseEntity.badRequest().build()
         }
 
-        // Handle any edge-cases
         val synqResponse = synqService.createOrder(payload.toOrder().toSynqPayload())
+        // If SynQ didn't throw an error, but returned something that wasn't a new order,
+        // then it is likely some error or edge-case
         if (!synqResponse.statusCode.isSameCodeAs(HttpStatus.CREATED)) {
             throw ServerErrorException("Unexpected error with SynQ", null)
         }

--- a/src/test/kotlin/no/nb/mlt/wls/order/controller/OrderControllerTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/controller/OrderControllerTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.test.runTest
 import no.nb.mlt.wls.EnableTestcontainers
 import no.nb.mlt.wls.core.data.HostName
 import no.nb.mlt.wls.core.data.Owner
+import no.nb.mlt.wls.core.data.synq.SynqError
 import no.nb.mlt.wls.order.model.OrderLineStatus
 import no.nb.mlt.wls.order.model.OrderReceiver
 import no.nb.mlt.wls.order.model.OrderStatus
@@ -109,6 +110,18 @@ class OrderControllerTest(
     @Test
     @WithMockUser
     fun `createOrder handles SynQ error`() {
+        coEvery {
+            synqOrderService.createOrder(any())
+        } returns ResponseEntity.internalServerError().body(SynqError(9001, "Unexpected error"))
+
+        webTestClient
+            .mutateWith(csrf())
+            .post()
+            .uri("/batch/create")
+            .accept(MediaType.APPLICATION_JSON)
+            .bodyValue(testOrderPayload)
+            .exchange()
+            .expectStatus().is5xxServerError
     }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/src/test/kotlin/no/nb/mlt/wls/order/controller/OrderControllerTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/controller/OrderControllerTest.kt
@@ -1,6 +1,7 @@
 package no.nb.mlt.wls.order.controller
 
 import com.ninjasquad.springmockk.MockkBean
+import io.mockk.coEvery
 import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.runBlocking
@@ -18,6 +19,7 @@ import no.nb.mlt.wls.order.payloads.toOrder
 import no.nb.mlt.wls.order.repository.OrderRepository
 import no.nb.mlt.wls.order.service.OrderService
 import no.nb.mlt.wls.order.service.SynqOrderService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -28,8 +30,12 @@ import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWeb
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.csrf
 import org.springframework.test.web.reactive.server.WebTestClient
+import java.net.URI
 
 @EnableTestcontainers
 @TestInstance(PER_CLASS)
@@ -61,6 +67,25 @@ class OrderControllerTest(
     @WithMockUser
     fun `createOrder with valid payload creates order`() =
         runTest {
+            coEvery {
+                synqOrderService.createOrder(any())
+            } returns ResponseEntity.created(URI.create("")).build()
+
+            webTestClient
+                .mutateWith(csrf())
+                .post()
+                .uri("/batch/create")
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(testOrderPayload)
+                .exchange()
+                .expectStatus().isCreated
+
+            val order = repository.findByHostNameAndHostOrderId(testOrderPayload.hostName, testOrderPayload.hostOrderId).awaitSingle()
+
+            assertThat(order)
+                .isNotNull
+                .extracting("callbackUrl", "status")
+                .containsExactly("callbackUrl", "Not started")
         }
 
     @Test

--- a/src/test/kotlin/no/nb/mlt/wls/order/controller/OrderControllerTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/controller/OrderControllerTest.kt
@@ -85,7 +85,7 @@ class OrderControllerTest(
             assertThat(order)
                 .isNotNull
                 .extracting("callbackUrl", "status")
-                .containsExactly("callbackUrl", "Not started")
+                .containsExactly("callbackUrl", OrderStatus.NOT_STARTED)
         }
 
     @Test

--- a/src/test/kotlin/no/nb/mlt/wls/order/model/OrderModelConversionTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/model/OrderModelConversionTest.kt
@@ -1,0 +1,106 @@
+package no.nb.mlt.wls.order.model
+
+import no.nb.mlt.wls.core.data.HostName
+import no.nb.mlt.wls.core.data.Owner
+import no.nb.mlt.wls.core.data.synq.SynqOwner
+import no.nb.mlt.wls.order.payloads.ApiOrderPayload
+import no.nb.mlt.wls.order.payloads.SynqOrderPayload
+import no.nb.mlt.wls.order.payloads.toApiOrderPayload
+import no.nb.mlt.wls.order.payloads.toOrder
+import no.nb.mlt.wls.order.payloads.toSynqPayload
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class OrderModelConversionTest {
+    private val testApiOrderPayload =
+        ApiOrderPayload(
+            orderId = "hostOrderId",
+            hostName = HostName.AXIELL,
+            hostOrderId = "hostOrderId",
+            status = OrderStatus.NOT_STARTED,
+            productLine = listOf(ProductLine("hostProductId", OrderLineStatus.NOT_STARTED)),
+            orderType = OrderType.LOAN,
+            owner = Owner.NB,
+            receiver = OrderReceiver(
+                name = "name",
+                address = "address",
+                postalCode = "postalCode",
+                city = "city",
+                phoneNumber = "phoneNumber",
+                location = "location"
+            ),
+            callbackUrl = "callbackUrl"
+        )
+
+    private val testOrder =
+        Order(
+            hostName = HostName.AXIELL,
+            hostOrderId = "hostOrderId",
+            status = OrderStatus.NOT_STARTED,
+            productLine = listOf(ProductLine("hostProductId", OrderLineStatus.NOT_STARTED)),
+            orderType = OrderType.LOAN,
+            owner = Owner.NB,
+            receiver = OrderReceiver(
+                name = "name",
+                address = "address",
+                postalCode = "postalCode",
+                city = "city",
+                phoneNumber = "phoneNumber",
+                location = "location"
+            ),
+            callbackUrl = "callbackUrl"
+        )
+
+    private val testSynqOrderPayload =
+        SynqOrderPayload(
+            orderId = "hostOrderId",
+            orderType = SynqOrderPayload.SynqOrderType.STANDARD,
+            dispatchDate = LocalDateTime.now(),
+            orderDate = LocalDateTime.now(),
+            priority = 1,
+            owner = SynqOwner.NB,
+            orderLine = listOf(SynqOrderPayload.OrderLine(1, "hostProductId", 1.0))
+        )
+
+    @Test
+    fun `order converts to API payload`() {
+        val payload = testOrder.toApiOrderPayload()
+
+        assertThat(payload.orderId).isEqualTo(testApiOrderPayload.orderId)
+        assertThat(payload.hostName).isEqualTo(testApiOrderPayload.hostName)
+        assertThat(payload.hostOrderId).isEqualTo(testApiOrderPayload.hostOrderId)
+        assertThat(payload.status).isEqualTo(testApiOrderPayload.status)
+        assertThat(payload.productLine).isEqualTo(testApiOrderPayload.productLine)
+        assertThat(payload.orderType).isEqualTo(testApiOrderPayload.orderType)
+        assertThat(payload.owner).isEqualTo(testApiOrderPayload.owner)
+        assertThat(payload.receiver).isEqualTo(testApiOrderPayload.receiver)
+        assertThat(payload.callbackUrl).isEqualTo(testApiOrderPayload.callbackUrl)
+    }
+
+    @Test
+    fun `order converts to SynQ payload`() {
+        val synqPayload = testOrder.toSynqPayload()
+
+        // Dates are not compared as they are generated in the function
+        assertThat(synqPayload.orderId).isEqualTo(testSynqOrderPayload.orderId)
+        assertThat(synqPayload.orderType).isEqualTo(testSynqOrderPayload.orderType)
+        assertThat(synqPayload.priority).isEqualTo(testSynqOrderPayload.priority)
+        assertThat(synqPayload.owner).isEqualTo(testSynqOrderPayload.owner)
+        assertThat(synqPayload.orderLine).isEqualTo(testSynqOrderPayload.orderLine)
+    }
+
+    @Test
+    fun `API payload converts to order`() {
+        val order = testApiOrderPayload.toOrder()
+
+        assertThat(order.hostName).isEqualTo(testOrder.hostName)
+        assertThat(order.hostOrderId).isEqualTo(testOrder.hostOrderId)
+        assertThat(order.status).isEqualTo(testOrder.status)
+        assertThat(order.productLine).isEqualTo(testOrder.productLine)
+        assertThat(order.orderType).isEqualTo(testOrder.orderType)
+        assertThat(order.owner).isEqualTo(testOrder.owner)
+        assertThat(order.receiver).isEqualTo(testOrder.receiver)
+        assertThat(order.callbackUrl).isEqualTo(testOrder.callbackUrl)
+    }
+}

--- a/src/test/kotlin/no/nb/mlt/wls/order/model/OrderModelConversionTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/model/OrderModelConversionTest.kt
@@ -22,14 +22,15 @@ class OrderModelConversionTest {
             productLine = listOf(ProductLine("hostProductId", OrderLineStatus.NOT_STARTED)),
             orderType = OrderType.LOAN,
             owner = Owner.NB,
-            receiver = OrderReceiver(
-                name = "name",
-                address = "address",
-                postalCode = "postalCode",
-                city = "city",
-                phoneNumber = "phoneNumber",
-                location = "location"
-            ),
+            receiver =
+                OrderReceiver(
+                    name = "name",
+                    address = "address",
+                    postalCode = "postalCode",
+                    city = "city",
+                    phoneNumber = "phoneNumber",
+                    location = "location"
+                ),
             callbackUrl = "callbackUrl"
         )
 
@@ -41,14 +42,15 @@ class OrderModelConversionTest {
             productLine = listOf(ProductLine("hostProductId", OrderLineStatus.NOT_STARTED)),
             orderType = OrderType.LOAN,
             owner = Owner.NB,
-            receiver = OrderReceiver(
-                name = "name",
-                address = "address",
-                postalCode = "postalCode",
-                city = "city",
-                phoneNumber = "phoneNumber",
-                location = "location"
-            ),
+            receiver =
+                OrderReceiver(
+                    name = "name",
+                    address = "address",
+                    postalCode = "postalCode",
+                    city = "city",
+                    phoneNumber = "phoneNumber",
+                    location = "location"
+                ),
             callbackUrl = "callbackUrl"
         )
 

--- a/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
@@ -1,9 +1,12 @@
 package no.nb.mlt.wls.order.service
 
+import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import no.nb.mlt.wls.core.data.HostName
 import no.nb.mlt.wls.core.data.Owner
 import no.nb.mlt.wls.order.model.OrderLineStatus
@@ -12,13 +15,19 @@ import no.nb.mlt.wls.order.model.OrderStatus
 import no.nb.mlt.wls.order.model.OrderType
 import no.nb.mlt.wls.order.model.ProductLine
 import no.nb.mlt.wls.order.payloads.ApiOrderPayload
+import no.nb.mlt.wls.order.payloads.toOrder
 import no.nb.mlt.wls.order.repository.OrderRepository
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.server.ServerErrorException
 import org.springframework.web.server.ServerWebInputException
+import reactor.core.publisher.Mono
 
 @TestInstance(PER_CLASS)
 @ExtendWith(MockKExtension::class)
@@ -34,24 +43,68 @@ class OrderServiceTest {
 
     @Test
     fun `save called with payload missing orderId throws`() {
-        assertExceptionThrownWithMessage(top.copy(orderId = ""), "The order's orderId can not be blank", ServerWebInputException::class.java)
-        assertExceptionThrownWithMessage(top.copy(orderId = "\t\n"), "The order's orderId can not be blank", ServerWebInputException::class.java)
-        assertExceptionThrownWithMessage(top.copy(orderId = "      "), "The order's orderId can not be blank", ServerWebInputException::class.java)
+        assertExceptionThrownWithMessage(top.copy(orderId = ""), "orderId is required", ServerWebInputException::class.java)
+        assertExceptionThrownWithMessage(top.copy(orderId = "\t\n"), "orderId is required", ServerWebInputException::class.java)
+        assertExceptionThrownWithMessage(top.copy(orderId = "      "), "orderId is required", ServerWebInputException::class.java)
     }
 
     @Test
     fun `save called with payload missing hostOrderId throws`() {
         assertExceptionThrownWithMessage(top.copy(hostOrderId = ""), "The order's hostOrderId is required", ServerWebInputException::class.java)
-        assertExceptionThrownWithMessage(
-            top.copy(hostOrderId = "\t\n"),
-            "The order's hostOrderId is required",
-            ServerWebInputException::class.java
-        )
-        assertExceptionThrownWithMessage(
-            top.copy(hostOrderId = "      "),
-            "The order's hostOrderId is required",
-            ServerWebInputException::class.java
-        )
+        assertExceptionThrownWithMessage(top.copy(hostOrderId = "\t\n"), "The order's hostOrderId is required", ServerWebInputException::class.java)
+        assertExceptionThrownWithMessage(top.copy(hostOrderId = "      "), "The order's hostOrderId is required", ServerWebInputException::class.java)
+    }
+
+    @Test
+    fun `save when order exists throws`() {
+        runTest {
+            every { db.findByHostNameAndHostOrderId(top.hostName, top.hostOrderId) } returns Mono.just(top.toOrder())
+            assertThat(cut.createOrder(top).statusCode.is4xxClientError)
+        }
+    }
+
+    @Test
+    fun `save called with Order that SynQ says exists throws`() {
+        runTest {
+            every { db.findByHostNameAndHostOrderId(top.hostName, top.hostOrderId) } returns Mono.empty()
+            coEvery { synq.createOrder(any()) } throws ServerErrorException("Duplicate order found in in SynQ", null)
+
+            assertExceptionThrownWithMessage(top, "Duplicate order", ServerErrorException::class.java)
+        }
+    }
+
+    @Test
+    fun `save called when synq fails is handled gracefully`() {
+        every { db.findByHostNameAndHostOrderId(top.hostName, top.hostOrderId) } returns Mono.empty()
+        coEvery { synq.createOrder(any()) } throws ServerErrorException("Unexpected error", null)
+
+        assertThatExceptionOfType(ServerErrorException::class.java).isThrownBy {
+            runBlocking {
+                cut.createOrder(top)
+            }
+        }
+    }
+
+    @Test
+    fun `save called when db is down is handled gracefully`() {
+        every { db.findByHostNameAndHostOrderId(any(), any()) } returns Mono.never()
+
+        assertThatExceptionOfType(ServerErrorException::class.java).isThrownBy {
+            runBlocking {
+                cut.createOrder(top)
+            }
+        }
+    }
+
+    @Test
+    fun `save with no errors returns created order`() {
+        runTest {
+            every { db.findByHostNameAndHostOrderId(top.hostName, top.hostOrderId) } returns Mono.empty()
+            coEvery { synq.createOrder(any()) } returns ResponseEntity(HttpStatus.CREATED)
+            every { db.save(any()) } returns Mono.just(top.toOrder())
+
+            assertThat(cut.createOrder(top).statusCode.is2xxSuccessful)
+        }
     }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
@@ -50,9 +50,14 @@ class OrderServiceTest {
 
     @Test
     fun `save called with payload missing hostOrderId throws`() {
-        assertExceptionThrownWithMessage(top.copy(hostOrderId = ""), "The order's hostOrderId is required", ServerWebInputException::class.java)
-        assertExceptionThrownWithMessage(top.copy(hostOrderId = "\t\n"), "The order's hostOrderId is required", ServerWebInputException::class.java)
-        assertExceptionThrownWithMessage(top.copy(hostOrderId = "      "), "The order's hostOrderId is required", ServerWebInputException::class.java)
+        assertExceptionThrownWithMessage(top.copy(hostOrderId = ""), "hostOrderId is required", ServerWebInputException::class.java)
+        assertExceptionThrownWithMessage(top.copy(hostOrderId = "\t\n"), "hostOrderId is required", ServerWebInputException::class.java)
+        assertExceptionThrownWithMessage(top.copy(hostOrderId = "      "), "hostOrderId is required", ServerWebInputException::class.java)
+    }
+
+    @Test
+    fun `save with payload missing product lines throws`() {
+        assertExceptionThrownWithMessage(top.copy(productLine = listOf()), "must contain product lines", ServerWebInputException::class.java)
     }
 
     @Test
@@ -87,11 +92,13 @@ class OrderServiceTest {
 
     @Test
     fun `save called when db is down is handled gracefully`() {
-        every { db.findByHostNameAndHostOrderId(any(), any()) } returns Mono.never()
+        runTest {
+            every { db.findByHostNameAndHostOrderId(any(), any()) } returns Mono.never()
 
-        assertThatExceptionOfType(ServerErrorException::class.java).isThrownBy {
-            runBlocking {
-                cut.createOrder(top)
+            assertThatExceptionOfType(ServerErrorException::class.java).isThrownBy {
+                runBlocking {
+                    cut.createOrder(top)
+                }
             }
         }
     }

--- a/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
@@ -2,6 +2,8 @@ package no.nb.mlt.wls.order.service
 
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.runBlocking
 import no.nb.mlt.wls.core.data.HostName
 import no.nb.mlt.wls.core.data.Owner
 import no.nb.mlt.wls.order.model.OrderLineStatus
@@ -12,9 +14,15 @@ import no.nb.mlt.wls.order.model.ProductLine
 import no.nb.mlt.wls.order.payloads.ApiOrderPayload
 import no.nb.mlt.wls.order.repository.OrderRepository
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.web.server.ServerWebInputException
 
+@TestInstance(PER_CLASS)
+@ExtendWith(MockKExtension::class)
 class OrderServiceTest {
-
     @MockK
     private lateinit var db: OrderRepository
 
@@ -24,7 +32,27 @@ class OrderServiceTest {
     @InjectMockKs
     private lateinit var cut: OrderService // cut = class under test
 
+    @Test
+    fun `save called with payload missing orderId throws`() {
+        assertExceptionThrownWithMessage(top.copy(orderId = ""), "The order's orderId can not be blank", ServerWebInputException::class.java)
+        assertExceptionThrownWithMessage(top.copy(orderId = "\t\n"), "The order's orderId can not be blank", ServerWebInputException::class.java)
+        assertExceptionThrownWithMessage(top.copy(orderId = "      "), "The order's orderId can not be blank", ServerWebInputException::class.java)
+    }
 
+    @Test
+    fun `save called with payload missing hostOrderId throws`() {
+        assertExceptionThrownWithMessage(top.copy(hostOrderId = ""), "The order's hostOrderId is required", ServerWebInputException::class.java)
+        assertExceptionThrownWithMessage(
+            top.copy(hostOrderId = "\t\n"),
+            "The order's hostOrderId is required",
+            ServerWebInputException::class.java
+        )
+        assertExceptionThrownWithMessage(
+            top.copy(hostOrderId = "      "),
+            "The order's hostOrderId is required",
+            ServerWebInputException::class.java
+        )
+    }
 
 // /////////////////////////////////////////////////////////////////////////////
 // //////////////////////////////// Test Help //////////////////////////////////
@@ -40,14 +68,15 @@ class OrderServiceTest {
             productLine = listOf(ProductLine("mlt-420", OrderLineStatus.NOT_STARTED)),
             orderType = OrderType.LOAN,
             owner = Owner.NB,
-            receiver = OrderReceiver(
-                name = "name",
-                address = "address",
-                postalCode = "postalCode",
-                city = "city",
-                phoneNumber = "phoneNumber",
-                location = "location"
-            ),
+            receiver =
+                OrderReceiver(
+                    name = "name",
+                    address = "address",
+                    postalCode = "postalCode",
+                    city = "city",
+                    phoneNumber = "phoneNumber",
+                    location = "location"
+                ),
             callbackUrl = "callbackUrl"
         )
 
@@ -56,6 +85,6 @@ class OrderServiceTest {
         message: String,
         exception: Class<T>
     ) = assertThatExceptionOfType(exception).isThrownBy {
-        cut.createOrder(payload)
+        runBlocking { cut.createOrder(payload) }
     }.withMessageContaining(message)
 }

--- a/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
@@ -93,7 +93,7 @@ class OrderServiceTest {
     @Test
     fun `save called when db is down is handled gracefully`() {
         runTest {
-            every { db.findByHostNameAndHostOrderId(any(), any()) } returns Mono.never()
+            every { db.findByHostNameAndHostOrderId(any(), any()) } returns Mono.error(Exception("db is down"))
 
             assertThatExceptionOfType(ServerErrorException::class.java).isThrownBy {
                 runBlocking {

--- a/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
@@ -79,7 +79,7 @@ class OrderServiceTest {
     }
 
     @Test
-    fun `save called when synq fails is handled gracefully`() {
+    fun `save called when SynQ fails is handled gracefully`() {
         every { db.findByHostNameAndHostOrderId(top.hostName, top.hostOrderId) } returns Mono.empty()
         coEvery { synq.createOrder(any()) } throws ServerErrorException("Unexpected error", null)
 

--- a/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/service/OrderServiceTest.kt
@@ -1,0 +1,61 @@
+package no.nb.mlt.wls.order.service
+
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import no.nb.mlt.wls.core.data.HostName
+import no.nb.mlt.wls.core.data.Owner
+import no.nb.mlt.wls.order.model.OrderLineStatus
+import no.nb.mlt.wls.order.model.OrderReceiver
+import no.nb.mlt.wls.order.model.OrderStatus
+import no.nb.mlt.wls.order.model.OrderType
+import no.nb.mlt.wls.order.model.ProductLine
+import no.nb.mlt.wls.order.payloads.ApiOrderPayload
+import no.nb.mlt.wls.order.repository.OrderRepository
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+
+class OrderServiceTest {
+
+    @MockK
+    private lateinit var db: OrderRepository
+
+    @MockK
+    private lateinit var synq: SynqOrderService
+
+    @InjectMockKs
+    private lateinit var cut: OrderService // cut = class under test
+
+
+
+// /////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////// Test Help //////////////////////////////////
+// /////////////////////////////////////////////////////////////////////////////
+
+    // Will be used in most tests (top = test order payload)
+    private val top =
+        ApiOrderPayload(
+            orderId = "axiell-order-69",
+            hostName = HostName.AXIELL,
+            hostOrderId = "axiell-order-69",
+            status = OrderStatus.NOT_STARTED,
+            productLine = listOf(ProductLine("mlt-420", OrderLineStatus.NOT_STARTED)),
+            orderType = OrderType.LOAN,
+            owner = Owner.NB,
+            receiver = OrderReceiver(
+                name = "name",
+                address = "address",
+                postalCode = "postalCode",
+                city = "city",
+                phoneNumber = "phoneNumber",
+                location = "location"
+            ),
+            callbackUrl = "callbackUrl"
+        )
+
+    private fun <T : Throwable> assertExceptionThrownWithMessage(
+        payload: ApiOrderPayload,
+        message: String,
+        exception: Class<T>
+    ) = assertThatExceptionOfType(exception).isThrownBy {
+        cut.createOrder(payload)
+    }.withMessageContaining(message)
+}

--- a/src/test/kotlin/no/nb/mlt/wls/product/model/ProductModelConversionTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/product/model/ProductModelConversionTest.kt
@@ -1,11 +1,10 @@
-package no.nb.mlt.wls.product
+package no.nb.mlt.wls.product.model
 
 import no.nb.mlt.wls.core.data.Environment
 import no.nb.mlt.wls.core.data.HostName
 import no.nb.mlt.wls.core.data.Owner
 import no.nb.mlt.wls.core.data.Packaging
 import no.nb.mlt.wls.core.data.synq.SynqOwner
-import no.nb.mlt.wls.product.model.Product
 import no.nb.mlt.wls.product.payloads.ApiProductPayload
 import no.nb.mlt.wls.product.payloads.SynqProductPayload
 import no.nb.mlt.wls.product.payloads.toApiPayload
@@ -14,8 +13,8 @@ import no.nb.mlt.wls.product.payloads.toSynqPayload
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class ProductConvertiontests {
-    val testProductPayload =
+class ProductModelConversionTest {
+    private val testProductPayload =
         ApiProductPayload(
             hostId = "mlt-test-1234",
             hostName = HostName.AXIELL,
@@ -28,7 +27,7 @@ class ProductConvertiontests {
             quantity = 1.0
         )
 
-    val testProduct =
+    private val testProduct =
         Product(
             hostId = "mlt-test-1234",
             hostName = HostName.AXIELL,
@@ -41,7 +40,7 @@ class ProductConvertiontests {
             quantity = 1.0
         )
 
-    val testSynqPayload =
+    private val testSynqPayload =
         SynqProductPayload(
             productId = "mlt-test-1234",
             owner = SynqOwner.NB,
@@ -54,7 +53,7 @@ class ProductConvertiontests {
         )
 
     @Test
-    fun `product converts to payload`() {
+    fun `product converts to API payload`() {
         val payload = testProduct.toApiPayload()
         assertThat(payload.hostId).isEqualTo(testProductPayload.hostId)
         assertThat(payload.hostName).isEqualTo(testProductPayload.hostName)
@@ -80,7 +79,7 @@ class ProductConvertiontests {
     }
 
     @Test
-    fun `payload converts to product`() {
+    fun `API payload converts to product`() {
         val product = testProductPayload.toProduct()
         assertThat(product.hostId).isEqualTo(testProduct.hostId)
         assertThat(product.hostName).isEqualTo(testProduct.hostName)
@@ -91,17 +90,5 @@ class ProductConvertiontests {
         assertThat(product.owner).isEqualTo(testProduct.owner)
         assertThat(product.location).isEqualTo(testProduct.location)
         assertThat(product.quantity).isEqualTo(testProduct.quantity)
-    }
-
-    @Test
-    fun `payload converts to SynQ payload`() {
-        val synq = testProductPayload.toProduct().toSynqPayload()
-        assertThat(synq.hostName).isEqualTo(testSynqPayload.hostName)
-        assertThat(synq.productId).isEqualTo(testSynqPayload.productId)
-        assertThat(synq.productUom.uomId).isEqualTo(testSynqPayload.productUom.uomId)
-        assertThat(synq.productCategory).isEqualTo(testSynqPayload.productCategory)
-        assertThat(synq.barcode.barcodeId).isEqualTo(testSynqPayload.barcode.barcodeId)
-        assertThat(synq.owner).isEqualTo(testSynqPayload.owner)
-        assertThat(synq.description).isEqualTo(testSynqPayload.description)
     }
 }


### PR DESCRIPTION
Adds a some tests for OrderService

Has one breaking change with renaming `getByHostNameAndHostOrderId` to `findByHostNameAndHostOrderId` in OrderRepository, to be more consistent with ProductRepository