### PR TITLE
MLT-41 Change handling of duplicate orders

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/order/controller/OrderController.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/controller/OrderController.kt
@@ -26,8 +26,29 @@ class OrderController(val orderService: OrderService) {
     )
     @ApiResponses(
         ApiResponse(
+            responseCode = "200",
+            description = """Order with given 'hostName' and 'hostOrderId' already exists in the system.
+                No new order was created, neither was the old order updated.
+                Existing order information is returned for inspection.
+                In rare cases the response body may be empty, that can happen if Hermes WLS does not
+                have the information about the order stored in its database and is unable to retrieve
+                the existing order information from the storage system.""",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ApiOrderPayload::class)
+                )
+            ]
+        ),
+        ApiResponse(
             responseCode = "201",
-            description = "Created order for specified products to appropriate systems"
+            description = "Created order for specified products to appropriate systems",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ApiOrderPayload::class)
+                )
+            ]
         ),
         ApiResponse(
             responseCode = "400",

--- a/src/main/kotlin/no/nb/mlt/wls/order/controller/OrderController.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/controller/OrderController.kt
@@ -52,8 +52,7 @@ class OrderController(val orderService: OrderService) {
         ),
         ApiResponse(
             responseCode = "400",
-            description =
-                """Order payload is invalid and was not created.
+            description = """Order payload is invalid and was not created.
                 An empty error message means the order already exists with the current ID.
                 Otherwise, the error message contains information about the invalid fields.""",
             content = [Content(schema = Schema())]

--- a/src/main/kotlin/no/nb/mlt/wls/order/service/OrderService.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/order/service/OrderService.kt
@@ -39,14 +39,17 @@ class OrderService(val db: OrderRepository, val synqService: SynqOrderService) {
                 .awaitSingleOrNull()
 
         if (existingOrder != null) {
-            return ResponseEntity.badRequest().build()
+            return ResponseEntity.ok(existingOrder.toApiOrderPayload())
         }
 
         val synqResponse = synqService.createOrder(payload.toOrder().toSynqPayload())
-        // If SynQ didn't throw an error, but returned something that wasn't a new order,
-        // then it is likely some error or edge-case
-        if (!synqResponse.statusCode.isSameCodeAs(HttpStatus.CREATED)) {
+        // If SynQ didn't throw an error, but returned 4xx/5xx, then it is likely some error or edge-case we haven't handled
+        if (synqResponse.statusCode.is4xxClientError || synqResponse.statusCode.is5xxServerError) {
             throw ServerErrorException("Unexpected error with SynQ", null)
+        }
+        // If SynQ returned a 200 OK then it means it exists from before, and we can return empty response (since we don't have any order info)
+        if (synqResponse.statusCode.isSameCodeAs(HttpStatus.OK)) {
+            return ResponseEntity.ok().build()
         }
 
         // Return what the database saved, as it could contain changes

--- a/src/main/kotlin/no/nb/mlt/wls/product/controller/ProductController.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/product/controller/ProductController.kt
@@ -20,23 +20,23 @@ import org.springframework.web.bind.annotation.RestController
 class ProductController(val productService: ProductService) {
     @Operation(
         summary = "Register a product in the storage system",
-        description =
-            "Register data about the product in Hermes WLS and appropriate storage system, " +
-                "so that the physical product can be placed in the physical storage. " +
-                "NOTE: When registering new product quantity and location are set to default values (0.0 and null). " +
-                "Hence you should not provide these values in the payload, or at least know they will be overwritten."
+        description = """
+            Register data about the product in Hermes WLS and appropriate storage system,
+            so that the physical product can be placed in the physical storage.
+            NOTE: When registering new product quantity and location are set to default values (0.0 and null).
+            Hence you should not provide these values in the payload, or at least know they will be overwritten."""
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description =
-                    "Product with given 'hostName' and 'hostId' already exists in the system. " +
-                        "No new product was created, neither was the old product updated. " +
-                        "Existing product information is returned for inspection. " +
-                        "In rare cases the response body may be empty, that can happen if Hermes WLS " +
-                        "does not have the information about product stored in its database and is " +
-                        "unable to retrieve the existing product information from the storage system.",
+                description = """
+                    Product with given 'hostName' and 'hostId' already exists in the system.
+                    No new product was created, neither was the old product updated.
+                    Existing product information is returned for inspection.
+                    In rare cases the response body may be empty, that can happen if Hermes WLS
+                    does not have the information about the product stored in its database and
+                    is unable to retrieve the existing product information from the storage system.""",
                 content = [
                     Content(
                         mediaType = "application/json",
@@ -46,10 +46,10 @@ class ProductController(val productService: ProductService) {
             ),
             ApiResponse(
                 responseCode = "201",
-                description =
-                    "Product payload is valid and the product information was registered successfully. " +
-                        "Product was created in the appropriate storage system. " +
-                        "New product information is returned for inspection.",
+                description = """
+                    Product payload is valid and the product information was registered successfully.
+                    Product was created in the appropriate storage system.
+                    New product information is returned for inspection.""",
                 content = [
                     Content(
                         mediaType = "application/json",
@@ -59,9 +59,9 @@ class ProductController(val productService: ProductService) {
             ),
             ApiResponse(
                 responseCode = "400",
-                description =
-                    "Product payload is invalid and no new product was created. " +
-                        "Error message contains information about the invalid fields.",
+                description = """
+                    Product payload is invalid and no new product was created.
+                    Error message contains information about the invalid fields.""",
                 content = [Content(schema = Schema())]
             ),
             ApiResponse(

--- a/src/main/kotlin/no/nb/mlt/wls/product/controller/ProductController.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/product/controller/ProductController.kt
@@ -20,8 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 class ProductController(val productService: ProductService) {
     @Operation(
         summary = "Register a product in the storage system",
-        description = """
-            Register data about the product in Hermes WLS and appropriate storage system,
+        description = """Register data about the product in Hermes WLS and appropriate storage system,
             so that the physical product can be placed in the physical storage.
             NOTE: When registering new product quantity and location are set to default values (0.0 and null).
             Hence you should not provide these values in the payload, or at least know they will be overwritten."""
@@ -30,8 +29,7 @@ class ProductController(val productService: ProductService) {
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = """
-                    Product with given 'hostName' and 'hostId' already exists in the system.
+                description = """Product with given 'hostName' and 'hostId' already exists in the system.
                     No new product was created, neither was the old product updated.
                     Existing product information is returned for inspection.
                     In rare cases the response body may be empty, that can happen if Hermes WLS
@@ -46,8 +44,7 @@ class ProductController(val productService: ProductService) {
             ),
             ApiResponse(
                 responseCode = "201",
-                description = """
-                    Product payload is valid and the product information was registered successfully.
+                description = """Product payload is valid and the product information was registered successfully.
                     Product was created in the appropriate storage system.
                     New product information is returned for inspection.""",
                 content = [
@@ -59,8 +56,7 @@ class ProductController(val productService: ProductService) {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = """
-                    Product payload is invalid and no new product was created.
+                description = """Product payload is invalid and no new product was created.
                     Error message contains information about the invalid fields.""",
                 content = [Content(schema = Schema())]
             ),


### PR DESCRIPTION
This pull requests aims to make handling of duplicate orders similar to the way we handle duplicate products.
It comes with the same weakness in case SynQ informs us that the order is a duplicate, not our DB. Problem being we have no information about the order and no way of getting that information through API.