### PR TITLE
Fix not being able to send orders to SynQ

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqOrderPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqOrderPayload.kt
@@ -21,8 +21,7 @@ data class SynqOrderPayload(
     val priority: Int,
     val owner: SynqOwner,
     val orderLine: List<OrderLine>,
-    val customer: String? = null,
-    val shippingAddress: ShippingAddress? = null
+    val customer: String? = null
 ) {
     data class OrderLine(
         @Min(1)
@@ -30,21 +29,6 @@ data class SynqOrderPayload(
         val productId: String,
         val quantityOrdered: Double
     )
-
-    data class ShippingAddress(
-        val address: Address?
-    ) {
-        data class Address(
-            val contactPerson: String? = null,
-            val addressLine1: String? = null,
-            val city: String? = null,
-            val state: String? = null,
-            val postalCode: String? = null,
-            val country: String? = null,
-            val phoneNumber: String? = null,
-            val email: String? = null
-        )
-    }
 
     enum class SynqOrderType(private val type: String) {
         STANDARD("Standard");
@@ -65,7 +49,7 @@ fun Order.toSynqPayload() =
         // When order was made in SynQ, if we want to we can omit it and SynQ will set it to current date itself
         orderDate = LocalDateTime.now(),
         // TODO: we don't get it from API so we set it to 1, is other value more appropriate?
-        priority = 1,
+        priority = 5,
         owner = owner?.toSynqOwner() ?: SynqOwner.NB,
         orderLine =
             productLine.mapIndexed { index, it ->
@@ -75,19 +59,7 @@ fun Order.toSynqPayload() =
                     quantityOrdered = 1.0
                 )
             },
-        customer = receiver.name,
-        shippingAddress = receiver.toShippingAddress()
-    )
-
-fun Order.Receiver.toShippingAddress(): SynqOrderPayload.ShippingAddress =
-    SynqOrderPayload.ShippingAddress(
-        SynqOrderPayload.ShippingAddress.Address(
-            contactPerson = name,
-            addressLine1 = address,
-            city = city,
-            postalCode = postalCode,
-            phoneNumber = phoneNumber
-        )
+        customer = receiver.name
     )
 
 fun Item.toSynqPayload() =


### PR DESCRIPTION
Some of the fields in our data structures are not required for our use-cases, and prevents us from creating new orders