### PR TITLE
MLT-0053 Add use-case for moving items

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/application/restapi/item/ProductController.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/restapi/item/ProductController.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import no.nb.mlt.wls.domain.ports.inbound.AddNewItem
 import no.nb.mlt.wls.domain.ports.inbound.GetItem
+import no.nb.mlt.wls.domain.ports.inbound.MoveItem
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -21,7 +22,8 @@ import org.springframework.web.server.ServerWebInputException
 @Tag(name = "Product Controller", description = "API for managing products in Hermes WLS")
 class ProductController(
     private val addNewItem: AddNewItem,
-    private val getItem: GetItem
+    private val getItem: GetItem,
+    private val moveItem: MoveItem
 ) {
     @Operation(
         summary = "Register a product in the storage system",

--- a/src/main/kotlin/no/nb/mlt/wls/domain/WLSService.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/WLSService.kt
@@ -61,6 +61,12 @@ class WLSService(
         quantity: Double,
         location: String
     ): Item {
+        if (quantity < 0.0) {
+            throw ValidationException("Quantity can not be negative")
+        }
+        if (location.isBlank()) {
+            throw ValidationException("Location can not be blank")
+        }
         val item = getItem(hostName, hostId) ?: throw ItemNotFoundException("Item with id '$hostId' does not exist for '$hostName'")
         return itemRepository.moveItem(item.hostId, item.hostName, quantity, location)
     }

--- a/src/main/kotlin/no/nb/mlt/wls/domain/WLSService.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/WLSService.kt
@@ -12,6 +12,8 @@ import no.nb.mlt.wls.domain.ports.inbound.DeleteOrder
 import no.nb.mlt.wls.domain.ports.inbound.GetItem
 import no.nb.mlt.wls.domain.ports.inbound.GetOrder
 import no.nb.mlt.wls.domain.ports.inbound.ItemMetadata
+import no.nb.mlt.wls.domain.ports.inbound.ItemNotFoundException
+import no.nb.mlt.wls.domain.ports.inbound.MoveItem
 import no.nb.mlt.wls.domain.ports.inbound.OrderNotFoundException
 import no.nb.mlt.wls.domain.ports.inbound.ServerException
 import no.nb.mlt.wls.domain.ports.inbound.UpdateOrder
@@ -32,7 +34,7 @@ class WLSService(
     private val itemRepository: ItemRepository,
     private val orderRepository: OrderRepository,
     private val storageSystemFacade: StorageSystemFacade
-) : AddNewItem, CreateOrder, DeleteOrder, UpdateOrder, GetOrder, GetItem {
+) : AddNewItem, CreateOrder, DeleteOrder, UpdateOrder, GetOrder, GetItem, MoveItem {
     override suspend fun addItem(itemMetadata: ItemMetadata): Item {
         getItem(itemMetadata.hostName, itemMetadata.hostId)?.let {
             logger.info { "Item already exists: $it" }
@@ -51,6 +53,16 @@ class WLSService(
                 }
             }
             .awaitSingle()
+    }
+
+    override suspend fun moveItem(
+        hostId: String,
+        hostName: HostName,
+        quantity: Double,
+        location: String
+    ): Item {
+        val item = getItem(hostName, hostId) ?: throw ItemNotFoundException("Item with id '$hostId' does not exist for '$hostName'")
+        return itemRepository.moveItem(item.hostId, item.hostName, quantity, location).awaitSingle()
     }
 
     override suspend fun createOrder(orderDTO: CreateOrderDTO): Order {

--- a/src/main/kotlin/no/nb/mlt/wls/domain/WLSService.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/WLSService.kt
@@ -78,7 +78,7 @@ class WLSService(
         }
 
         val itemIds = orderDTO.orderItems.map { ItemId(orderDTO.hostName, it.hostId) }
-        if (!itemRepository.doesAllItemsExist(itemIds)) {
+        if (!itemRepository.doesEveryItemExist(itemIds)) {
             throw ValidationException("All order items in order must exist")
         }
 
@@ -110,7 +110,7 @@ class WLSService(
         callbackUrl: String
     ): Order {
         val itemIds = itemHostIds.map { ItemId(hostName, it) }
-        if (!itemRepository.doesAllItemsExist(itemIds)) {
+        if (!itemRepository.doesEveryItemExist(itemIds)) {
             throw ValidationException("All order items in order must exist")
         }
 

--- a/src/main/kotlin/no/nb/mlt/wls/domain/WLSService.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/WLSService.kt
@@ -62,7 +62,7 @@ class WLSService(
         location: String
     ): Item {
         val item = getItem(hostName, hostId) ?: throw ItemNotFoundException("Item with id '$hostId' does not exist for '$hostName'")
-        return itemRepository.moveItem(item.hostId, item.hostName, quantity, location).awaitSingle()
+        return itemRepository.moveItem(item.hostId, item.hostName, quantity, location)
     }
 
     override suspend fun createOrder(orderDTO: CreateOrderDTO): Order {

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/ItemNotFoundException.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/ItemNotFoundException.kt
@@ -1,0 +1,3 @@
+package no.nb.mlt.wls.domain.ports.inbound
+
+class ItemNotFoundException(override val message: String) : RuntimeException(message)

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/MoveItem.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/MoveItem.kt
@@ -1,0 +1,21 @@
+package no.nb.mlt.wls.domain.ports.inbound
+
+import no.nb.mlt.wls.domain.model.HostName
+import no.nb.mlt.wls.domain.model.Item
+
+/**
+ * This port is used for handling messages regarding items moving
+ * inside the storage system.
+ * Some examples include handling status messages when crates arrive
+ * at picking stations, or when items return to the
+ * storage systems.
+ * In both cases we want to know where the item went, and if the count changed
+ */
+interface MoveItem {
+    suspend fun moveItem(
+        hostId: String,
+        hostName: HostName,
+        quantity: Double,
+        location: String
+    ): Item
+}

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/UpdateOrder.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/UpdateOrder.kt
@@ -17,6 +17,4 @@ interface UpdateOrder {
     ): Order
 }
 
-class ValidationException(override val message: String, cause: Throwable? = null) : RuntimeException(message, cause)
-
 class IllegalOrderStateException(override val message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/ValidationException.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/ValidationException.kt
@@ -1,0 +1,3 @@
+package no.nb.mlt.wls.domain.ports.inbound
+
+class ValidationException(override val message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/ItemRepository.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/ItemRepository.kt
@@ -12,7 +12,7 @@ interface ItemRepository {
 
     fun createItem(item: Item): Mono<Item>
 
-    suspend fun doesAllItemsExist(ids: List<ItemId>): Boolean
+    suspend fun doesEveryItemExist(ids: List<ItemId>): Boolean
 
     suspend fun moveItem(
         hostId: String,

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/ItemRepository.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/ItemRepository.kt
@@ -13,6 +13,13 @@ interface ItemRepository {
     fun createItem(item: Item): Mono<Item>
 
     suspend fun doesAllItemsExist(ids: List<ItemId>): Boolean
+
+    fun moveItem(
+        hostId: String,
+        hostName: HostName,
+        quantity: Double,
+        location: String
+    ): Mono<Item>
 }
 
 data class ItemId(val hostName: HostName, val hostId: String)

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/ItemRepository.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/ItemRepository.kt
@@ -14,12 +14,14 @@ interface ItemRepository {
 
     suspend fun doesAllItemsExist(ids: List<ItemId>): Boolean
 
-    fun moveItem(
+    suspend fun moveItem(
         hostId: String,
         hostName: HostName,
         quantity: Double,
         location: String
-    ): Mono<Item>
+    ): Item
 }
 
 data class ItemId(val hostName: HostName, val hostId: String)
+
+class ItemMovingException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/item/MongoItemRepository.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/item/MongoItemRepository.kt
@@ -44,7 +44,7 @@ class ItemRepositoryMongoAdapter(
         return mongoRepo.save(item.toMongoItem()).map(MongoItem::toItem)
     }
 
-    override suspend fun doesAllItemsExist(ids: List<ItemId>): Boolean {
+    override suspend fun doesEveryItemExist(ids: List<ItemId>): Boolean {
         return mongoRepo.countItemsMatchingIds(ids)
             .map {
                 logger.debug { "Counted items matching ids: $ids, count: $it" }

--- a/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
@@ -120,7 +120,6 @@ class WLSServiceTest {
         }
     }
 
-    @Suppress("ReactiveStreamsUnusedPublisher")
     @Test
     fun `moveItem should return when item successfully moves`() {
         val expectedItem =

--- a/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
@@ -158,6 +158,38 @@ class WLSServiceTest {
     }
 
     @Test
+    fun `moveItem throws when count is invalid`() {
+        coEvery { itemRepoMock.moveItem(any(), any(), -1.0, any()) } throws ValidationException("Location cannot be blank")
+
+        val cut = WLSService(itemRepoMock, orderRepoMock, storageSystemRepoMock)
+        runTest {
+            assertThrows<RuntimeException> {
+                cut.moveItem(testItem.hostId, testItem.hostName, -1.0, "   ")
+            }
+
+            coVerify(exactly = 0) { itemRepoMock.getItem(any(), any()) }
+            coVerify(exactly = 0) { itemRepoMock.moveItem(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { storageSystemRepoMock.createOrder(any()) }
+        }
+    }
+
+    @Test
+    fun `moveItem throws when location is blank`() {
+        coEvery { itemRepoMock.moveItem(any(), any(), any(), any()) } throws ValidationException("Item not found")
+
+        val cut = WLSService(itemRepoMock, orderRepoMock, storageSystemRepoMock)
+        runTest {
+            assertThrows<RuntimeException> {
+                cut.moveItem(testItem.hostId, testItem.hostName, 1.0, " ")
+            }
+
+            coVerify(exactly = 0) { itemRepoMock.getItem(any(), any()) }
+            coVerify(exactly = 0) { itemRepoMock.moveItem(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { storageSystemRepoMock.createOrder(any()) }
+        }
+    }
+
+    @Test
     fun `createOrder should save order in db and storage system`() {
         val expectedOrder = testOrder.copy()
 

--- a/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
@@ -162,7 +162,7 @@ class WLSServiceTest {
         val expectedOrder = testOrder.copy()
 
         coEvery { orderRepoMock.getOrder(any(), any()) } answers { null }
-        coEvery { itemRepoMock.doesAllItemsExist(any()) } answers { true }
+        coEvery { itemRepoMock.doesEveryItemExist(any()) } answers { true }
         coEvery { orderRepoMock.createOrder(any()) } answers { expectedOrder }
         coJustRun { storageSystemRepoMock.createOrder(any()) }
 
@@ -201,7 +201,7 @@ class WLSServiceTest {
     @Test
     fun `createOrder should fail if some of the items does not exist`() {
         coEvery { orderRepoMock.getOrder(any(), any()) } answers { null }
-        coEvery { itemRepoMock.doesAllItemsExist(any()) } answers { false }
+        coEvery { itemRepoMock.doesEveryItemExist(any()) } answers { false }
 
         val cut = WLSService(itemRepoMock, orderRepoMock, storageSystemRepoMock)
         runTest {
@@ -262,7 +262,7 @@ class WLSServiceTest {
     @Test
     fun `updateOrder with valid items should complete`() {
         val cut = WLSService(itemRepoMock, orderRepoMock, storageSystemRepoMock)
-        coEvery { itemRepoMock.doesAllItemsExist(any()) } answers { true }
+        coEvery { itemRepoMock.doesEveryItemExist(any()) } answers { true }
         coEvery { orderRepoMock.getOrder(any(), any()) } answers { testOrder.copy() }
         coEvery { storageSystemRepoMock.updateOrder(any()) } answers { updatedOrder }
         coEvery { orderRepoMock.updateOrder(any()) } answers { updatedOrder }
@@ -279,7 +279,7 @@ class WLSServiceTest {
                 )
 
             assertThat(order).isEqualTo(updatedOrder)
-            coVerify(exactly = 1) { itemRepoMock.doesAllItemsExist(any()) }
+            coVerify(exactly = 1) { itemRepoMock.doesEveryItemExist(any()) }
             coVerify(exactly = 1) { orderRepoMock.getOrder(any(), any()) }
             coVerify(exactly = 1) { storageSystemRepoMock.updateOrder(any()) }
             coVerify(exactly = 1) { orderRepoMock.updateOrder(any()) }
@@ -290,7 +290,7 @@ class WLSServiceTest {
     fun `updateOrder should fail when order does not exist`() {
         val cut = WLSService(itemRepoMock, orderRepoMock, storageSystemRepoMock)
 
-        coEvery { itemRepoMock.doesAllItemsExist(any()) } answers { true }
+        coEvery { itemRepoMock.doesEveryItemExist(any()) } answers { true }
         coEvery { orderRepoMock.getOrder(any(), any()) } throws OrderNotFoundException("Order not found")
 
         runTest {
@@ -304,7 +304,7 @@ class WLSServiceTest {
                     testOrder.callbackUrl
                 )
             }
-            coVerify(exactly = 1) { itemRepoMock.doesAllItemsExist(any()) }
+            coVerify(exactly = 1) { itemRepoMock.doesEveryItemExist(any()) }
             coVerify(exactly = 1) { orderRepoMock.getOrder(any(), any()) }
             coVerify(exactly = 0) { storageSystemRepoMock.updateOrder(any()) }
             coVerify(exactly = 0) { orderRepoMock.updateOrder(any()) }
@@ -314,7 +314,7 @@ class WLSServiceTest {
     @Test
     fun `updateOrder should fail when items do not exist`() {
         val cut = WLSService(itemRepoMock, orderRepoMock, storageSystemRepoMock)
-        coEvery { itemRepoMock.doesAllItemsExist(any()) } answers { false }
+        coEvery { itemRepoMock.doesEveryItemExist(any()) } answers { false }
 
         runTest {
             assertThrows<ValidationException> {
@@ -327,7 +327,7 @@ class WLSServiceTest {
                     testOrder.callbackUrl
                 )
             }
-            coVerify(exactly = 1) { itemRepoMock.doesAllItemsExist(any()) }
+            coVerify(exactly = 1) { itemRepoMock.doesEveryItemExist(any()) }
             coVerify(exactly = 0) { orderRepoMock.getOrder(any(), any()) }
             coVerify(exactly = 0) { storageSystemRepoMock.updateOrder(any()) }
             coVerify(exactly = 0) { orderRepoMock.updateOrder(any()) }

--- a/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
@@ -164,7 +164,7 @@ class WLSServiceTest {
         val cut = WLSService(itemRepoMock, orderRepoMock, storageSystemRepoMock)
         runTest {
             assertThrows<RuntimeException> {
-                cut.moveItem(testItem.hostId, testItem.hostName, -1.0, "   ")
+                cut.moveItem(testItem.hostId, testItem.hostName, -1.0, "Somewhere nice")
             }
 
             coVerify(exactly = 0) { itemRepoMock.getItem(any(), any()) }


### PR DESCRIPTION
Originally planned as updating items - this PR implements the functionality to move items within WLS. This specific use-case is required for when the storage systems gives us various status updates when the items are withdrawn, inserted, or generally moved around