### PR TITLE
MLT-0061 Delete Orders from Storage Systems

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/application/hostapi/order/ApiOrderPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/hostapi/order/ApiOrderPayload.kt
@@ -60,12 +60,6 @@ data class ApiOrderPayload(
     )
     val orderType: Order.Type,
     @Schema(
-        description = "Who's the owner of the material in the order.",
-        examples = ["NB", "ARKIVVERKET"],
-        accessMode = READ_ONLY
-    )
-    val owner: Owner?,
-    @Schema(
         description = "Who's the receiver of the material in the order."
     )
     val receiver: Receiver,
@@ -82,12 +76,12 @@ data class ApiOrderPayload(
             status = status ?: Order.Status.NOT_STARTED,
             orderLine = orderLine.map { it.toOrderItem() },
             orderType = orderType,
-            owner = owner,
+            owner = Owner.NB,
             receiver = receiver.toOrderReceiver(),
             callbackUrl = callbackUrl
         )
 
-    fun toCreateOrderDTO() =
+    fun toCreateOrderDTO(owner: Owner) =
         CreateOrderDTO(
             hostName = hostName,
             hostOrderId = hostOrderId,
@@ -135,7 +129,6 @@ fun Order.toApiOrderPayload() =
         status = status,
         orderLine = orderLine.map { it.toApiOrderLine() },
         orderType = orderType,
-        owner = owner,
         receiver = Receiver(receiver.name, receiver.address),
         callbackUrl = callbackUrl
     )

--- a/src/main/kotlin/no/nb/mlt/wls/application/hostapi/order/ApiOrderPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/hostapi/order/ApiOrderPayload.kt
@@ -69,6 +69,7 @@ data class ApiOrderPayload(
     )
     val callbackUrl: String
 ) {
+    // TODO - Only used for testing. Move this?
     fun toOrder() =
         Order(
             hostName = hostName,
@@ -76,6 +77,7 @@ data class ApiOrderPayload(
             status = status ?: Order.Status.NOT_STARTED,
             orderLine = orderLine.map { it.toOrderItem() },
             orderType = orderType,
+            // FIXME - Temporary hardcoding, not ideal
             owner = Owner.NB,
             receiver = receiver.toOrderReceiver(),
             callbackUrl = callbackUrl

--- a/src/main/kotlin/no/nb/mlt/wls/domain/model/HostName.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/model/HostName.kt
@@ -8,6 +8,7 @@ enum class HostName {
     ASTA
 }
 
+// TODO - Remove
 fun throwIfInvalidClientName(
     clientName: String,
     hostName: HostName

--- a/src/main/kotlin/no/nb/mlt/wls/domain/model/HostName.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/model/HostName.kt
@@ -4,7 +4,8 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
 enum class HostName {
-    AXIELL
+    AXIELL,
+    ASTA
 }
 
 fun throwIfInvalidClientName(

--- a/src/main/kotlin/no/nb/mlt/wls/domain/model/Order.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/model/Order.kt
@@ -12,7 +12,7 @@ data class Order(
     val status: Status,
     val orderLine: List<OrderItem>,
     val orderType: Type,
-    val owner: Owner?,
+    val owner: Owner,
     val receiver: Receiver,
     val callbackUrl: String
 ) {

--- a/src/main/kotlin/no/nb/mlt/wls/domain/model/Owner.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/model/Owner.kt
@@ -1,5 +1,6 @@
 package no.nb.mlt.wls.domain.model
 
 enum class Owner {
-    NB
+    NB,
+    ARKIVVERKET
 }

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/CreateOrder.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/CreateOrder.kt
@@ -13,7 +13,7 @@ data class CreateOrderDTO(
     val hostOrderId: String,
     val orderLine: List<OrderItem>,
     val orderType: Order.Type,
-    val owner: Owner?,
+    val owner: Owner,
     val receiver: Order.Receiver,
     val callbackUrl: String
 ) {

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/StorageSystemFacade.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/StorageSystemFacade.kt
@@ -1,6 +1,5 @@
 package no.nb.mlt.wls.domain.ports.outbound
 
-import no.nb.mlt.wls.domain.model.HostName
 import no.nb.mlt.wls.domain.model.Item
 import no.nb.mlt.wls.domain.model.Order
 
@@ -11,10 +10,7 @@ interface StorageSystemFacade {
     @Throws(DuplicateResourceException::class)
     suspend fun createOrder(order: Order)
 
-    suspend fun deleteOrder(
-        hostName: HostName,
-        hostOrderId: String
-    )
+    suspend fun deleteOrder(order: Order)
 
     @Throws(StorageSystemException::class)
     suspend fun updateOrder(order: Order): Order

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqAdapter.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqAdapter.kt
@@ -1,7 +1,6 @@
 package no.nb.mlt.wls.infrastructure.synq
 
 import kotlinx.coroutines.reactor.awaitSingle
-import no.nb.mlt.wls.domain.model.HostName
 import no.nb.mlt.wls.domain.model.Item
 import no.nb.mlt.wls.domain.model.Order
 import no.nb.mlt.wls.domain.ports.inbound.OrderNotFoundException
@@ -69,13 +68,10 @@ class SynqAdapter(
             .awaitSingle()
     }
 
-    override suspend fun deleteOrder(
-        hostName: HostName,
-        hostOrderId: String
-    ) {
+    override suspend fun deleteOrder(order: Order) {
         webClient
             .delete()
-            .uri(URI.create("$baseUrl/orders/$hostName/$hostOrderId"))
+            .uri(URI.create("$baseUrl/orders/${order.owner}/${order.hostOrderId}"))
             .retrieve()
             .toEntity(SynqError::class.java)
             .onErrorMap(WebClientResponseException::class.java) { createServerError(it) }

--- a/src/test/kotlin/no/nb/mlt/wls/order/controller/OrderControllerTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/controller/OrderControllerTest.kt
@@ -451,7 +451,7 @@ class OrderControllerTest(
     fun `deleteOrder with valid data deletes order`() =
         runTest {
             coEvery {
-                synqAdapterMock.deleteOrder(any(), any())
+                synqAdapterMock.deleteOrder(any())
             } answers {}
 
             webTestClient
@@ -476,7 +476,7 @@ class OrderControllerTest(
     fun `deleteOrder with blank hostOrderId returns 400`() =
         runTest {
             coEvery {
-                synqAdapterMock.deleteOrder(any(), any())
+                synqAdapterMock.deleteOrder(any())
             } answers {}
 
             webTestClient
@@ -493,7 +493,7 @@ class OrderControllerTest(
     fun `deleteOrder with order that does not exist returns 404`() =
         runTest {
             coEvery {
-                synqAdapterMock.deleteOrder(any(), any())
+                synqAdapterMock.deleteOrder(any())
             } answers {}
 
             webTestClient
@@ -509,7 +509,7 @@ class OrderControllerTest(
     @Test
     fun `deleteOrder handles synq error`() {
         coEvery {
-            synqAdapterMock.deleteOrder(any(), any())
+            synqAdapterMock.deleteOrder(any())
         } throws (
             StorageSystemException(
                 "Unexpected error",
@@ -541,7 +541,6 @@ class OrderControllerTest(
             status = Order.Status.NOT_STARTED,
             orderLine = listOf(OrderLine("mlt-420", Order.OrderItem.Status.NOT_STARTED)),
             orderType = Order.Type.LOAN,
-            owner = Owner.NB,
             receiver = Receiver(name = "name", address = "address"),
             callbackUrl = "https://callback.com/order"
         )
@@ -557,7 +556,6 @@ class OrderControllerTest(
             status = Order.Status.NOT_STARTED,
             orderLine = listOf(OrderLine("item-123456", Order.OrderItem.Status.NOT_STARTED)),
             orderType = Order.Type.LOAN,
-            owner = Owner.NB,
             receiver = Receiver(name = "name", address = "address"),
             callbackUrl = "https://callback.com/order"
         )


### PR DESCRIPTION
This should also resolve MLT-0062.
The PR expands the port (use-case) of the delete endpoint to use the order model. Alternatively this could be implemented to use a DTO to be more precise, but this should be fine for now in order to correctly delete orders from the storage systems. 