### PR TITLE
MLT-0063 Use Ints for quantity

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
@@ -82,12 +82,12 @@ data class ApiItemPayload(
     @Schema(
         description =
             "Quantity on hand of the item, this denotes if the item is in storage or not. " +
-                "If the item is in storage then quantity is 1.0, if it's not in storage then quantity is 0.0.",
-        examples = [ "0.0", "1.0"],
+                "If the item is in storage then quantity is at least 1, if it's not in storage then quantity is 0.",
+        examples = [ "0", "1"],
         accessMode = READ_ONLY,
         required = false
     )
-    val quantity: Double?
+    val quantity: Int?
 ) {
     fun toItem(): Item =
         Item(

--- a/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ItemController.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ItemController.kt
@@ -34,7 +34,7 @@ class ItemController(
         description = """Register data about the item in Hermes WLS and appropriate storage system,
             so that the physical item can be placed in the physical storage.
             An item is also called item by some storage systems and users, those mean the same thing in Hermes.
-            NOTE: When registering new item quantity and location are set to default values (0.0 and null).
+            NOTE: When registering new item quantity and location are set to default values (0 and null).
             Hence you should not provide these values in the payload, or at least know they will be overwritten."""
     )
     @ApiResponses(

--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqBatchMoveItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqBatchMoveItemPayload.kt
@@ -131,7 +131,7 @@ data class Product(
         example = "1.0"
     )
     @PositiveOrZero
-    val quantityOnHand: Double,
+    val quantityOnHand: Int,
     @Schema(
         description = "Signifies the product is marked as suspect in the storage system and needs to be manually verified.",
         example = "false"

--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqBatchMoveItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqBatchMoveItemPayload.kt
@@ -127,7 +127,9 @@ data class Product(
     )
     val productVersionId: String,
     @Schema(
-        description = "Quantity of the product in the transport unit, uses float, however in our case we operate only in whole numbers.",
+        description =
+            "Quantity of the product in the transport unit. Accepts doubles, " +
+                "however, this is converted as we operate only in whole numbers.",
         example = "1.0"
     )
     @PositiveOrZero

--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqBatchMoveItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqBatchMoveItemPayload.kt
@@ -127,9 +127,8 @@ data class Product(
     )
     val productVersionId: String,
     @Schema(
-        description =
-            "Quantity of the product in the transport unit. Accepts doubles, " +
-                "however, this is converted as we operate only in whole numbers.",
+        description = """Quantity of the product in the transport unit.
+            Accepts doubles, but they will be converted to integers.""",
         example = "1.0"
     )
     @PositiveOrZero

--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqController.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqController.kt
@@ -101,7 +101,7 @@ class SynqController(
         @RequestBody payload: SynqOrderPickingConfirmationPayload
     ) {
         payload.validate()
-        val hostIds: MutableMap<String, Double> = mutableMapOf()
+        val hostIds: MutableMap<String, Int> = mutableMapOf()
         val hostName = HostName.valueOf(payload.orderLine.first().hostName.uppercase())
         payload.orderLine.map { orderLine ->
             hostIds.put(

--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqOrderPickingConfirmationPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqOrderPickingConfirmationPayload.kt
@@ -124,7 +124,7 @@ data class OrderLine(
         description = "Quantity of the product/item.",
         example = "1.0"
     )
-    val quantity: Double,
+    val quantity: Int,
     @Schema(
         description = "List of attribute values of the product/item.",
         example = "[{...}]"

--- a/src/main/kotlin/no/nb/mlt/wls/domain/WLSService.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/WLSService.kt
@@ -83,7 +83,7 @@ class WLSService(
 
     override suspend fun pickItems(
         hostName: HostName,
-        itemsPickedMap: Map<String, Double>
+        itemsPickedMap: Map<String, Int>
     ) {
         val itemIds =
             itemsPickedMap.map {
@@ -99,8 +99,8 @@ class WLSService(
             // TODO - Get All Items function?
             val item = getItem(itemId.hostName, itemId.hostId)!!
 
-            val itemsInStockQuantity = item.quantity ?: 0.0
-            val pickedItemsQuantity = itemsPickedMap[item.hostId] ?: 0.0
+            val itemsInStockQuantity = item.quantity ?: 0
+            val pickedItemsQuantity = itemsPickedMap[item.hostId] ?: 0
 
             // In the case of over-picking, set quantity to zero
             // so that on return the database hopefully recovers
@@ -110,9 +110,9 @@ class WLSService(
                         "WLS DB has $itemsInStockQuantity stocked, and storage system tried to pick $pickedItemsQuantity"
                 }
             }
-            val quantity = Math.clamp(itemsInStockQuantity.minus(pickedItemsQuantity), 0.0, Double.MAX_VALUE)
+            val quantity = Math.clamp(itemsInStockQuantity.minus(pickedItemsQuantity).toLong(), 0, Int.MAX_VALUE)
             val location: String =
-                if (quantity == 0.0) {
+                if (quantity == 0) {
                     "WITH_LENDER"
                 } else if (item.location != null) {
                     item.location

--- a/src/main/kotlin/no/nb/mlt/wls/domain/model/Item.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/model/Item.kt
@@ -10,5 +10,5 @@ data class Item(
     val owner: Owner,
     val callbackUrl: String?,
     val location: String?,
-    val quantity: Double?
+    val quantity: Int?
 )

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/AddNewItem.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/AddNewItem.kt
@@ -21,8 +21,13 @@ data class ItemMetadata(
     val callbackUrl: String?
 )
 
+/**
+ * Maps and creates an Item from ItemMetadata
+ * Note that when registering products the quantity and location
+ * are always zero/empty, as they must be registered before being inserted into storage
+ */
 fun ItemMetadata.toItem(
-    quantity: Double? = 0.0,
+    quantity: Int? = 0,
     location: String? = null
 ) = Item(
     this.hostId,

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/MoveItem.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/MoveItem.kt
@@ -18,6 +18,6 @@ interface MoveItem {
 data class MoveItemPayload(
     val hostId: String,
     val hostName: HostName,
-    val quantity: Double,
+    val quantity: Int,
     val location: String
 )

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/PickItems.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/PickItems.kt
@@ -9,6 +9,6 @@ import no.nb.mlt.wls.domain.model.HostName
 interface PickItems {
     suspend fun pickItems(
         hostName: HostName,
-        itemsPickedMap: Map<String, Double>
+        itemsPickedMap: Map<String, Int>
     )
 }

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/ItemRepository.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/ItemRepository.kt
@@ -17,7 +17,7 @@ interface ItemRepository {
     suspend fun moveItem(
         hostId: String,
         hostName: HostName,
-        quantity: Double,
+        quantity: Int,
         location: String
     ): Item
 

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/NotificationItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/NotificationItemPayload.kt
@@ -68,7 +68,7 @@ data class NotificationItemPayload(
         accessMode = READ_ONLY,
         required = false
     )
-    val quantity: Double?
+    val quantity: Int?
 )
 
 fun NotificationItemPayload.toItem(): Item {

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/item/MongoItem.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/item/MongoItem.kt
@@ -18,7 +18,7 @@ data class MongoItem(
     val owner: Owner,
     val callbackUrl: String?,
     val location: String?,
-    val quantity: Double?
+    val quantity: Int?
 )
 
 fun Item.toMongoItem() =

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/item/MongoItemRepository.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/item/MongoItemRepository.kt
@@ -62,7 +62,7 @@ class ItemRepositoryMongoAdapter(
     override suspend fun moveItem(
         hostId: String,
         hostName: HostName,
-        quantity: Double,
+        quantity: Int,
         location: String
     ): Item {
         val itemsModified =
@@ -104,7 +104,7 @@ interface ItemMongoRepository : ReactiveMongoRepository<MongoItem, String> {
     fun findAndUpdateItemByHostNameAndHostId(
         hostName: HostName,
         hostId: String,
-        quantity: Double,
+        quantity: Int,
         location: String
     ): Mono<Long>
 }

--- a/src/test/kotlin/no/nb/mlt/wls/TraillingSlashRedirectTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/TraillingSlashRedirectTest.kt
@@ -88,6 +88,6 @@ class TraillingSlashRedirectTest(
             owner = Owner.NB,
             callbackUrl = "https://callback.com/item",
             location = "SYNQ_WAREHOUSE",
-            quantity = 1.0
+            quantity = 1
         )
 }

--- a/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
@@ -131,7 +131,7 @@ class WLSServiceTest {
         val expectedItem =
             testItem.copy(
                 location = "Somewhere nice",
-                quantity = 1.0
+                quantity = 1
             )
         coEvery { itemRepoMock.getItem(any(), any()) } returns testItem
         coEvery { itemRepoMock.moveItem(any(), any(), any(), any()) } returns expectedItem
@@ -166,12 +166,12 @@ class WLSServiceTest {
 
     @Test
     fun `moveItem throws when count is invalid`() {
-        coEvery { itemRepoMock.moveItem(any(), any(), -1.0, any()) } throws ValidationException("Location cannot be blank")
+        coEvery { itemRepoMock.moveItem(any(), any(), -1, any()) } throws ValidationException("Location cannot be blank")
 
         val cut = WLSService(itemRepoMock, orderRepoMock, storageSystemRepoMock, inventoryNotifierMock)
         runTest {
             assertThrows<RuntimeException> {
-                cut.moveItem(testMoveItemPayload.copy(quantity = -1.0))
+                cut.moveItem(testMoveItemPayload.copy(quantity = -1))
             }
 
             coVerify(exactly = 0) { itemRepoMock.getItem(any(), any()) }
@@ -445,7 +445,7 @@ class WLSServiceTest {
         MoveItemPayload(
             "12345",
             HostName.AXIELL,
-            1.0,
+            1,
             "Somewhere nice"
         )
 

--- a/src/test/kotlin/no/nb/mlt/wls/item/controller/ItemControllerTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/item/controller/ItemControllerTest.kt
@@ -90,7 +90,7 @@ class ItemControllerTest(
             assertThat(item)
                 .isNotNull
                 .extracting("description", "location", "quantity")
-                .containsExactly(testItemPayload.description, null, 0.0)
+                .containsExactly(testItemPayload.description, null, 0)
         }
 
     @Test
@@ -245,7 +245,7 @@ class ItemControllerTest(
             owner = Owner.NB,
             callbackUrl = "https://callback.com/item",
             location = "SYNQ_WAREHOUSE",
-            quantity = 1.0
+            quantity = 1
         )
 
     /**
@@ -262,7 +262,7 @@ class ItemControllerTest(
             owner = Owner.NB,
             callbackUrl = "https://callback.com/item",
             location = "SYNQ_WAREHOUSE",
-            quantity = 1.0
+            quantity = 1
         )
 
     fun populateDb() {

--- a/src/test/kotlin/no/nb/mlt/wls/item/model/ItemModelConversionTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/item/model/ItemModelConversionTest.kt
@@ -27,7 +27,7 @@ class ItemModelConversionTest {
             owner = Owner.NB,
             callbackUrl = "https://callback.com/item",
             location = "",
-            quantity = 1.0
+            quantity = 1
         )
 
     private val testItem =
@@ -41,7 +41,7 @@ class ItemModelConversionTest {
             owner = Owner.NB,
             callbackUrl = "https://callback.com/item",
             location = "",
-            quantity = 1.0
+            quantity = 1
         )
 
     private val testSynqPayload =
@@ -67,7 +67,7 @@ class ItemModelConversionTest {
             owner = Owner.NB,
             callbackUrl = "https://callback.com/item",
             location = "",
-            quantity = 1.0
+            quantity = 1
         )
 
     @Test

--- a/src/test/kotlin/no/nb/mlt/wls/item/model/ItemModelValidationTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/item/model/ItemModelValidationTest.kt
@@ -82,7 +82,7 @@ class ItemModelValidationTest {
 
     @Test
     fun `item with negative quantity should fail validation`() {
-        val item = validItem.copy(quantity = -1.0)
+        val item = validItem.copy(quantity = -1)
 
         val thrown = catchThrowable(item::validate)
 
@@ -119,6 +119,6 @@ class ItemModelValidationTest {
             owner = Owner.NB,
             callbackUrl = "https://callback.com/item",
             location = "location",
-            quantity = 1.0
+            quantity = 1
         )
 }

--- a/src/test/kotlin/no/nb/mlt/wls/order/controller/OrderControllerTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/controller/OrderControllerTest.kt
@@ -520,7 +520,7 @@ class OrderControllerTest(
                                 packaging = Packaging.NONE,
                                 owner = Owner.NB,
                                 location = "location",
-                                quantity = 1.0,
+                                quantity = 1,
                                 callbackUrl = "https://callback.com/item"
                             )
                         }

--- a/src/test/kotlin/no/nb/mlt/wls/synq/controller/SynqControllerTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/synq/controller/SynqControllerTest.kt
@@ -272,7 +272,7 @@ class SynqControllerTest(
                 .put()
                 .uri("/move-item")
                 .accept(MediaType.APPLICATION_JSON)
-                .bodyValue(batchMoveItemPayload.copy(loadUnit = listOf(product1.copy(quantityOnHand = -1.0))))
+                .bodyValue(batchMoveItemPayload.copy(loadUnit = listOf(product1.copy(quantityOnHand = -1))))
                 .exchange()
                 .expectStatus().isBadRequest
         }
@@ -314,7 +314,7 @@ class SynqControllerTest(
             productId = "mlt-12345",
             productOwner = "NB",
             productVersionId = "Default",
-            quantityOnHand = 1.0,
+            quantityOnHand = 1,
             suspect = false,
             attributeValue =
                 listOf(
@@ -338,7 +338,7 @@ class SynqControllerTest(
             productId = "mlt-54321",
             productOwner = "NB",
             productVersionId = "Default",
-            quantityOnHand = 69.0,
+            quantityOnHand = 69,
             suspect = false,
             attributeValue =
                 listOf(
@@ -366,7 +366,7 @@ class SynqControllerTest(
             packaging = Packaging.BOX,
             callbackUrl = "https://callback.com/item",
             location = null,
-            quantity = 0.0
+            quantity = 0
         )
 
     private val item2 =
@@ -380,7 +380,7 @@ class SynqControllerTest(
             packaging = Packaging.BOX,
             callbackUrl = "https://callback.com/item",
             location = null,
-            quantity = 0.0
+            quantity = 0
         )
 
     private val order =

--- a/src/test/kotlin/no/nb/mlt/wls/synq/model/SynqModelConversionTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/synq/model/SynqModelConversionTest.kt
@@ -44,7 +44,7 @@ class SynqModelConversionTest {
             productId = "mlt-12345",
             productOwner = "NB",
             productVersionId = "Default",
-            quantityOnHand = 1.0,
+            quantityOnHand = 1,
             suspect = false,
             attributeValue =
                 listOf(

--- a/src/test/kotlin/no/nb/mlt/wls/synq/model/SynqModelValidationTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/synq/model/SynqModelValidationTest.kt
@@ -161,7 +161,7 @@ class SynqModelValidationTest {
             orderTuType = "UFO",
             productId = "item-123",
             productVersionId = "1.0",
-            quantity = 1.0,
+            quantity = 1,
             attributeValue =
                 listOf(
                     AttributeValue(
@@ -180,7 +180,7 @@ class SynqModelValidationTest {
             orderTuType = "UFO",
             productId = "item-456",
             productVersionId = "1.0",
-            quantity = 1.0,
+            quantity = 1,
             attributeValue =
                 listOf(
                     AttributeValue(


### PR DESCRIPTION
For our use-cases we do not need doubles for our Item models. This PR refactors this to use integers instead