### PR TITLE
MLT-0045 Add Hostname on Order IDs for SynQ Orders

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqController.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqController.kt
@@ -101,8 +101,12 @@ class SynqController(
         @RequestBody payload: SynqOrderPickingConfirmationPayload
     ) {
         payload.validate()
+        // TODO - Migrate functionality to the Order domain model instead of handling it here
         val hostIds: MutableMap<String, Double> = mutableMapOf()
         val hostName = HostName.valueOf(payload.orderLine.first().hostName.uppercase())
+        if (!orderId.startsWith(hostName.toString())) {
+            TODO("Log this error, or throw an exception?")
+        }
         payload.orderLine.map { orderLine ->
             hostIds.put(
                 orderLine.productId,

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqOrderPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqOrderPayload.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
 import jakarta.validation.constraints.Min
-import no.nb.mlt.wls.domain.model.Item
 import no.nb.mlt.wls.domain.model.Order
 import no.nb.mlt.wls.domain.model.Packaging
 import no.nb.mlt.wls.infrastructure.synq.SynqProductPayload.SynqPackaging
@@ -53,7 +52,7 @@ data class ShippingAddress(
 
 fun Order.toSynqPayload() =
     SynqOrderPayload(
-        orderId = hostOrderId,
+        orderId = hostName.toString().uppercase() + "_" + hostOrderId,
         orderType = orderType.toSynqOrderType(),
         // When order should be dispatched, AFAIK it's not used by us as we don't receive orders in future
         dispatchDate = LocalDateTime.now(),
@@ -61,7 +60,7 @@ fun Order.toSynqPayload() =
         orderDate = LocalDateTime.now(),
         // TODO: we don't get it from API so we set it to 1, is other value more appropriate?
         priority = 5,
-        owner = owner?.toSynqOwner() ?: SynqOwner.NB,
+        owner = owner.toSynqOwner(),
         orderLine =
             orderLine.mapIndexed { index, it ->
                 SynqOrderPayload.OrderLine(

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqOrderPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqOrderPayload.kt
@@ -78,18 +78,6 @@ fun Order.toSynqPayload() =
             )
     )
 
-fun Item.toSynqPayload() =
-    SynqProductPayload(
-        productId = hostId,
-        owner = owner.toSynqOwner(),
-        barcode = SynqProductPayload.Barcode(hostId),
-        description = description,
-        productCategory = itemCategory,
-        productUom = SynqProductPayload.ProductUom(packaging.toSynqPackaging()),
-        confidential = false,
-        hostName = hostName.toString()
-    )
-
 fun Packaging.toSynqPackaging(): SynqPackaging =
     when (this) {
         Packaging.NONE -> OBJ

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqProductPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqProductPayload.kt
@@ -1,5 +1,7 @@
 package no.nb.mlt.wls.infrastructure.synq
 
+import no.nb.mlt.wls.domain.model.Item
+
 data class SynqProductPayload(
     val productId: String,
     val owner: SynqOwner,
@@ -19,3 +21,15 @@ data class SynqProductPayload(
 
     data class ProductUom(val uomId: SynqPackaging)
 }
+
+fun Item.toSynqPayload() =
+    SynqProductPayload(
+        productId = hostId,
+        owner = owner.toSynqOwner(),
+        barcode = SynqProductPayload.Barcode(hostId),
+        description = description,
+        productCategory = itemCategory,
+        productUom = SynqProductPayload.ProductUom(packaging.toSynqPackaging()),
+        confidential = false,
+        hostName = hostName.toString()
+    )

--- a/src/test/kotlin/no/nb/mlt/wls/order/model/OrderModelConversionTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/model/OrderModelConversionTest.kt
@@ -50,7 +50,7 @@ class OrderModelConversionTest {
 
     private val testSynqOrderPayload =
         SynqOrderPayload(
-            orderId = "hostOrderId",
+            orderId = "AXIELL_hostOrderId",
             orderType = SynqOrderPayload.SynqOrderType.STANDARD,
             dispatchDate = LocalDateTime.now(),
             orderDate = LocalDateTime.now(),


### PR DESCRIPTION
Prevents order conflicts with multiple hosts.

Remains a draft we decide where it is best to handle the validation for this (likely domain, or should it happen in the service?).