### PR TITLE
MLT-0086 Item Model Update

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
@@ -74,14 +74,13 @@ data class ApiItemPayload(
         examples = ["UNKNOWN", "WITH_LENDER", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"],
         required = false
     )
-    val location: String?,
+    val location: String,
     @Schema(
         description = """Quantity on hand of the item, this easily denotes if the item is in the storage or not.
                 If the item is in storage then quantity is 1, if it's not in storage then quantity is 0.""",
-        examples = [ "0", "1"],
-        required = false
+        examples = [ "0", "1"]
     )
-    val quantity: Int?
+    val quantity: Int
 ) {
     fun toItem(): Item =
         Item(
@@ -117,11 +116,11 @@ data class ApiItemPayload(
             throw ValidationException("The item's 'description' is required, and it cannot be blank")
         }
 
-        if (location != null && location.isBlank()) {
+        if (location.isBlank()) {
             throw ValidationException("The item's 'location' cannot be blank if set")
         }
 
-        if (quantity != null && quantity != 0 && quantity != 1) {
+        if (quantity != 0 && quantity != 1) {
             throw ValidationException("The item's 'quantity' must be one or zero if set")
         }
 

--- a/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
@@ -6,7 +6,6 @@ import no.nb.mlt.wls.domain.model.HostName
 import no.nb.mlt.wls.domain.model.Item
 import no.nb.mlt.wls.domain.model.ItemCategory
 import no.nb.mlt.wls.domain.model.Packaging
-import no.nb.mlt.wls.domain.ports.inbound.ItemMetadata
 import no.nb.mlt.wls.domain.ports.inbound.ValidationException
 import org.apache.commons.validator.routines.UrlValidator
 
@@ -93,17 +92,6 @@ data class ApiItemPayload(
             callbackUrl = callbackUrl,
             location = location,
             quantity = quantity
-        )
-
-    fun toItemMetadata(): ItemMetadata =
-        ItemMetadata(
-            hostId = hostId,
-            hostName = hostName,
-            description = description,
-            itemCategory = itemCategory,
-            preferredEnvironment = preferredEnvironment,
-            packaging = packaging,
-            callbackUrl = callbackUrl
         )
 
     @Throws(ValidationException::class)

--- a/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
@@ -70,8 +70,7 @@ data class ApiItemPayload(
     val callbackUrl: String?,
     @Schema(
         description = """Where the item is located, can be used for tracking item movement through storage systems.""",
-        examples = ["UNKNOWN", "WITH_LENDER", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"],
-        required = false
+        examples = ["UNKNOWN", "WITH_LENDER", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"]
     )
     val location: String,
     @Schema(
@@ -105,11 +104,11 @@ data class ApiItemPayload(
         }
 
         if (location.isBlank()) {
-            throw ValidationException("The item's 'location' cannot be blank if set")
+            throw ValidationException("The item's 'location' is required, and it cannot be blank")
         }
 
         if (quantity != 0 && quantity != 1) {
-            throw ValidationException("The item's 'quantity' must be one or zero if set")
+            throw ValidationException("The item's 'quantity' must be one or zero")
         }
 
         if (callbackUrl != null && !isValidUrl(callbackUrl)) {

--- a/src/main/kotlin/no/nb/mlt/wls/domain/model/Item.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/model/Item.kt
@@ -16,7 +16,7 @@ data class Item(
     val quantity: Int
 ) {
     fun pickItem(amountPicked: Int): Item {
-        val itemsInStockQuantity = quantity ?: 0
+        val itemsInStockQuantity = quantity
 
         // In the case of over-picking, log it and set quantity to zero.
         // This is in hope that on return the database recovers

--- a/src/main/kotlin/no/nb/mlt/wls/domain/model/Item.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/model/Item.kt
@@ -12,8 +12,8 @@ data class Item(
     val preferredEnvironment: Environment,
     val packaging: Packaging,
     val callbackUrl: String?,
-    val location: String?,
-    val quantity: Int?
+    val location: String,
+    val quantity: Int
 ) {
     fun pickItem(amountPicked: Int): Item {
         val itemsInStockQuantity = quantity ?: 0
@@ -31,14 +31,8 @@ data class Item(
         val location: String =
             if (quantity == 0) {
                 "WITH_LENDER"
-            } else if (location != null) {
-                location
             } else {
-                // Rare edge case. Log it until we can determine if this actually happens in production
-                logger.error {
-                    "Item with ID '$hostId' for host '$hostName' without a location was picked. Location was set to 'UNKNOWN'."
-                }
-                "UNKNOWN"
+                location
             }
         return this.copy(quantity = quantity, location = location)
     }

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/AddNewItem.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/AddNewItem.kt
@@ -26,8 +26,8 @@ data class ItemMetadata(
  * are always zero/empty, as they must be registered before being inserted into storage
  */
 fun ItemMetadata.toItem(
-    quantity: Int? = 0,
-    location: String? = null
+    quantity: Int = 0,
+    location: String = "UNKNOWN"
 ) = Item(
     this.hostId,
     this.hostName,

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/NotificationItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/NotificationItemPayload.kt
@@ -73,14 +73,13 @@ data class NotificationItemPayload(
         examples = ["UNKNOWN", "WITH_LENDER", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"],
         required = false
     )
-    val location: String?,
+    val location: String,
     @Schema(
         description = """Quantity on hand of the item, this easily denotes if the item is in the storage or not.
                 If the item is in storage then quantity is 1, if it's not in storage then quantity is 0.""",
-        examples = [ "0.0", "1.0"],
-        required = false
+        examples = [ "0.0", "1.0"]
     )
-    val quantity: Int?
+    val quantity: Int
 )
 
 fun NotificationItemPayload.toItem(): Item {

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/item/MongoItem.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/item/MongoItem.kt
@@ -16,8 +16,8 @@ data class MongoItem(
     val preferredEnvironment: Environment,
     val packaging: Packaging,
     val callbackUrl: String?,
-    val location: String?,
-    val quantity: Int?
+    val location: String,
+    val quantity: Int
 )
 
 fun Item.toMongoItem() =

--- a/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
@@ -415,8 +415,8 @@ class WLSServiceTest {
             preferredEnvironment = Environment.NONE,
             packaging = Packaging.NONE,
             callbackUrl = "https://callback-wls.no/item",
-            location = null,
-            quantity = null
+            location = "UNKNOWN",
+            quantity = 0
         )
 
     private val testOrder =

--- a/src/test/kotlin/no/nb/mlt/wls/item/controller/ItemControllerTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/item/controller/ItemControllerTest.kt
@@ -90,7 +90,7 @@ class ItemControllerTest(
             assertThat(item)
                 .isNotNull
                 .extracting("description", "location", "quantity")
-                .containsExactly(testItemPayload.description, null, 0)
+                .containsExactly(testItemPayload.description, "UNKNOWN", 0)
         }
 
     @Test

--- a/src/test/kotlin/no/nb/mlt/wls/item/model/ItemModelValidationTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/item/model/ItemModelValidationTest.kt
@@ -21,8 +21,8 @@ class ItemModelValidationTest {
     fun `item with minimal valid data should pass validation`() {
         val item =
             validItem.copy(
-                quantity = null,
-                location = null,
+                quantity = 0,
+                location = "UNKNOWN",
                 callbackUrl = null
             )
 

--- a/src/test/kotlin/no/nb/mlt/wls/synq/controller/SynqControllerTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/synq/controller/SynqControllerTest.kt
@@ -365,7 +365,7 @@ class SynqControllerTest(
             preferredEnvironment = Environment.FRYS,
             packaging = Packaging.BOX,
             callbackUrl = "https://callback-wls.no/item",
-            location = null,
+            location = "UNKNOWN",
             quantity = 0
         )
 
@@ -378,7 +378,7 @@ class SynqControllerTest(
             preferredEnvironment = Environment.FRYS,
             packaging = Packaging.BOX,
             callbackUrl = "https://callback-wls.no/item",
-            location = null,
+            location = "UNKNOWN",
             quantity = 0
         )
 


### PR DESCRIPTION
Follows up on #55, and makes the `quantity` and `location` fields within the data non-nullable. This comes with more benefits than downsides, and simplifies the API.

It even removes the strange edge-case of picking an item where the location is null.  
```diff
        } else if (location != null) {
            location
        } else {
-            // Rare edge case. Log it until we can determine if this actually happens in production
-            logger.error {
-                "Item with ID '$hostId' for host '$hostName' without a location was picked. Location was set to 'UNKNOWN'."
-            }
            "UNKNOWN"
        }
```