### PR TITLE
MLT-121 Fix issues with order IDs from SynQ

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqOrderPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqOrderPayload.kt
@@ -69,7 +69,7 @@ data class ShippingAddress(
 
 fun Order.toSynqPayload() =
     SynqOrderPayload(
-        orderId = hostName.toString().uppercase() + "_" + hostOrderId,
+        orderId = hostName.toString().uppercase() + "---" + hostOrderId,
         orderType = orderType.toSynqOrderType(),
         // When order should be dispatched, AFAIK it's not used by us as we don't receive orders in future
         dispatchDate = LocalDateTime.now(),

--- a/src/test/kotlin/no/nb/mlt/wls/order/model/OrderModelConversionTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/model/OrderModelConversionTest.kt
@@ -66,7 +66,7 @@ class OrderModelConversionTest {
 
     private val testSynqOrderPayload =
         SynqOrderPayload(
-            orderId = "AXIELL_hostOrderId",
+            orderId = "AXIELL---hostOrderId",
             orderType = SynqOrderPayload.SynqOrderType.STANDARD,
             dispatchDate = LocalDateTime.now(),
             orderDate = LocalDateTime.now(),


### PR DESCRIPTION
Introduced normalization of order IDs to handle prefixed IDs consistently. Updated relevant logic in the SynqController and corresponding tests to use the normalized order IDs. Added a utility function `normalizeOrderId` and addressed potential edge cases in its implementation.