### PR TITLE
MLT-145 Add `messageId` to inventory notifier methods

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
@@ -19,7 +19,9 @@ import org.apache.commons.validator.routines.UrlValidator
       "itemCategory": "PAPER",
       "preferredEnvironment": "NONE",
       "packaging": "NONE",
-      "callbackUrl": "https://callback-wls.no/item"
+      "callbackUrl": "https://callback-wls.no/item",
+      "location": "SYNQ_WAREHOUSE",
+      "quantity": 1
     }
     """
 )

--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/InventoryNotifier.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/outbound/InventoryNotifier.kt
@@ -7,11 +7,13 @@ import java.time.Instant
 interface InventoryNotifier {
     fun itemChanged(
         item: Item,
-        eventTimestamp: Instant
+        eventTimestamp: Instant,
+        messageId: String
     )
 
     fun orderChanged(
         order: Order,
-        eventTimestamp: Instant
+        eventTimestamp: Instant,
+        messageId: String
     )
 }

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/CatalogEventProcessorAdapter.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/CatalogEventProcessorAdapter.kt
@@ -74,12 +74,12 @@ class CatalogEventProcessorAdapter(
     private suspend fun handleItemUpdate(event: ItemEvent) {
         logger.info { "CEPA: Processing ItemUpdate: $event" }
 
-        inventoryNotifier.itemChanged(event.item, event.eventTimestamp)
+        inventoryNotifier.itemChanged(event.item, event.eventTimestamp, event.id)
     }
 
     private suspend fun handleOrderUpdate(event: OrderEvent) {
         logger.info { "CEPA: Processing OrderUpdate: $event" }
 
-        inventoryNotifier.orderChanged(event.order, event.eventTimestamp)
+        inventoryNotifier.orderChanged(event.order, event.eventTimestamp, event.id)
     }
 }

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/InventoryNotifierAdapter.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/InventoryNotifierAdapter.kt
@@ -32,10 +32,11 @@ class InventoryNotifierAdapter(
 ) : InventoryNotifier {
     override fun itemChanged(
         item: Item,
-        eventTimestamp: Instant
+        eventTimestamp: Instant,
+        messageId: String
     ) {
         if (item.callbackUrl != null) {
-            val payload = objectMapper.writeValueAsString(item.toNotificationItemPayload(eventTimestamp))
+            val payload = objectMapper.writeValueAsString(item.toNotificationItemPayload(eventTimestamp, messageId))
             val timestamp = System.currentTimeMillis().toString()
 
             sendCallback(item.hostName, item.callbackUrl, payload, timestamp)
@@ -44,9 +45,10 @@ class InventoryNotifierAdapter(
 
     override fun orderChanged(
         order: Order,
-        eventTimestamp: Instant
+        eventTimestamp: Instant,
+        messageId: String
     ) {
-        val payload = objectMapper.writeValueAsString(order.toNotificationOrderPayload(eventTimestamp))
+        val payload = objectMapper.writeValueAsString(order.toNotificationOrderPayload(eventTimestamp, messageId))
         val timestamp = System.currentTimeMillis().toString()
 
         sendCallback(order.hostName, order.callbackUrl, payload, timestamp)

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/NotificationItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/NotificationItemPayload.kt
@@ -23,7 +23,9 @@ import java.time.Instant
       "packaging": "NONE",
       "callbackUrl": "https://callback-wls.no/item",
       "location": "SYNQ_WAREHOUSE",
-      "quantity": 1
+      "quantity": 1,
+      "eventTimestamp": "2025-03-21T20:30:00.000Z",
+      "messageId": "123e4567-e89b-12d3-a456-426614174000"
     }
     """
 )
@@ -92,7 +94,12 @@ data class NotificationItemPayload(
     )
     @JsonSerialize(using = ToStringSerializer::class)
     @JsonDeserialize(using = CustomInstantDeserializer::class)
-    val eventTimestamp: Instant
+    val eventTimestamp: Instant,
+    @Schema(
+        description = """This messages unique ID in UUID format, allows deduplication""",
+        example = "123e4567-e89b-12d3-a456-426614174000"
+    )
+    val messageId: String
 )
 
 fun NotificationItemPayload.toItem(): Item =
@@ -108,7 +115,10 @@ fun NotificationItemPayload.toItem(): Item =
         quantity = quantity
     )
 
-fun Item.toNotificationItemPayload(eventTimestamp: Instant): NotificationItemPayload =
+fun Item.toNotificationItemPayload(
+    eventTimestamp: Instant,
+    messageId: String
+): NotificationItemPayload =
     NotificationItemPayload(
         hostId = hostId,
         hostName = hostName,
@@ -119,5 +129,6 @@ fun Item.toNotificationItemPayload(eventTimestamp: Instant): NotificationItemPay
         callbackUrl = callbackUrl,
         location = location,
         quantity = quantity,
-        eventTimestamp = eventTimestamp
+        eventTimestamp = eventTimestamp,
+        messageId = messageId
     )

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/NotificationOrderPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/NotificationOrderPayload.kt
@@ -33,7 +33,9 @@ import java.time.Instant
         "region": "California",
         "postcode": "CA-55415"
       },
-      "callbackUrl": "https://callback-wls.no/order"
+      "callbackUrl": "https://callback-wls.no/order",
+      "eventTimestamp": "2025-03-21T20:30:00.000Z",
+      "messageId": "123e4567-e89b-12d3-a456-426614174000"
     }
     """
 )
@@ -101,7 +103,12 @@ data class NotificationOrderPayload(
     )
     @JsonSerialize(using = ToStringSerializer::class)
     @JsonDeserialize(using = CustomInstantDeserializer::class)
-    val eventTimestamp: Instant
+    val eventTimestamp: Instant,
+    @Schema(
+        description = """This messages unique ID in UUID format, allows deduplication""",
+        example = "123e4567-e89b-12d3-a456-426614174000"
+    )
+    val messageId: String
 ) {
     data class OrderLine(
         @Schema(
@@ -117,7 +124,10 @@ data class NotificationOrderPayload(
     )
 }
 
-fun Order.toNotificationOrderPayload(eventTimestamp: Instant) =
+fun Order.toNotificationOrderPayload(
+    eventTimestamp: Instant,
+    messageId: String
+): NotificationOrderPayload =
     NotificationOrderPayload(
         hostName = hostName,
         hostOrderId = hostOrderId,
@@ -129,5 +139,6 @@ fun Order.toNotificationOrderPayload(eventTimestamp: Instant) =
         address = address,
         note = note,
         callbackUrl = callbackUrl,
-        eventTimestamp = eventTimestamp
+        eventTimestamp = eventTimestamp,
+        messageId = messageId
     )

--- a/src/test/kotlin/no/nb/mlt/wls/infrastructure/CatalogEventProcessorTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/infrastructure/CatalogEventProcessorTest.kt
@@ -34,19 +34,19 @@ class CatalogEventProcessorTest {
             cut.handleEvent(event)
 
             assertThat(catalogMessageRepoMock.processed).hasSize(1).contains(event)
-            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(any(), event.eventTimestamp) }
+            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(any(), event.eventTimestamp, event.id) }
         }
 
     @Test
     fun `OrderUpdate event should handle error from inventory notifier`() =
         runTest {
-            coEvery { happyInventoryNotifierMock.orderChanged(any(), any()) } throws TimeoutException("Timed out")
+            coEvery { happyInventoryNotifierMock.orderChanged(any(), any(), any()) } throws TimeoutException("Timed out")
             val event = OrderEvent(testOrder)
 
             assertThrows<TimeoutException> { cut.handleEvent(event) }
 
             assertThat(catalogMessageRepoMock.processed).hasSize(0).doesNotContain(event)
-            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(any(), event.eventTimestamp) }
+            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(any(), event.eventTimestamp, event.id) }
         }
 
     @Test
@@ -57,19 +57,19 @@ class CatalogEventProcessorTest {
             cut.handleEvent(event)
 
             assertThat(catalogMessageRepoMock.processed).hasSize(1).contains(event)
-            coVerify(exactly = 1) { happyInventoryNotifierMock.itemChanged(any(), event.eventTimestamp) }
+            coVerify(exactly = 1) { happyInventoryNotifierMock.itemChanged(any(), event.eventTimestamp, event.id) }
         }
 
     @Test
     fun `Item Update event should handle error from inventory notifier`() =
         runTest {
-            coEvery { happyInventoryNotifierMock.itemChanged(any(), any()) } throws TimeoutException("Timed out")
+            coEvery { happyInventoryNotifierMock.itemChanged(any(), any(), any()) } throws TimeoutException("Timed out")
             val event = ItemEvent(testItem)
 
             assertThrows<TimeoutException> { cut.handleEvent(event) }
 
             assertThat(catalogMessageRepoMock.processed).hasSize(0).doesNotContain(event)
-            coVerify(exactly = 1) { happyInventoryNotifierMock.itemChanged(any(), event.eventTimestamp) }
+            coVerify(exactly = 1) { happyInventoryNotifierMock.itemChanged(any(), event.eventTimestamp, event.id) }
         }
 
     @Test
@@ -97,8 +97,16 @@ class CatalogEventProcessorTest {
             val item3event = ItemEvent(item3)
 
             // Make happyStorageSystemMock fail in during order1 update, and during item 2 creation
-            coEvery { happyInventoryNotifierMock.orderChanged(order1event2.order, order1event2.eventTimestamp) } throws TimeoutException("Timed out")
-            coEvery { happyInventoryNotifierMock.itemChanged(item2event.item, item2event.eventTimestamp) } throws TimeoutException("Timed out")
+            coEvery {
+                happyInventoryNotifierMock.orderChanged(order1event2.order, order1event2.eventTimestamp, order1event2.id)
+            } throws TimeoutException("Timed out")
+            coEvery {
+                happyInventoryNotifierMock.itemChanged(
+                    item2event.item,
+                    item2event.eventTimestamp,
+                    item2event.id
+                )
+            } throws TimeoutException("Timed out")
 
             // Create list of unprocessed events, mixing them, making sure order2 events happen "after" order1 fails, mix in items all over the list
             unprocessedEventsList.addAll(
@@ -123,17 +131,17 @@ class CatalogEventProcessorTest {
                 .contains(order1event1, order2event1, order2event2, item1event, item3event)
 
             // Make sure every event got called
-            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(order1event1.order, order1event1.eventTimestamp) }
-            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(order1event2.order, order1event2.eventTimestamp) }
+            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(order1event1.order, order1event1.eventTimestamp, order1event1.id) }
+            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(order1event2.order, order1event2.eventTimestamp, order1event2.id) }
             // Should not be called as update above should fail
-            coVerify(exactly = 0) { happyInventoryNotifierMock.orderChanged(order1event3.order, order1event3.eventTimestamp) }
+            coVerify(exactly = 0) { happyInventoryNotifierMock.orderChanged(order1event3.order, order1event3.eventTimestamp, order1event3.id) }
 
-            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(order2event1.order, order2event1.eventTimestamp) }
-            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(order2event2.order, order2event2.eventTimestamp) }
+            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(order2event1.order, order2event1.eventTimestamp, order2event1.id) }
+            coVerify(exactly = 1) { happyInventoryNotifierMock.orderChanged(order2event2.order, order2event2.eventTimestamp, order2event2.id) }
 
-            coVerify(exactly = 1) { happyInventoryNotifierMock.itemChanged(item1event.item, item1event.eventTimestamp) }
-            coVerify(exactly = 1) { happyInventoryNotifierMock.itemChanged(item2event.item, item2event.eventTimestamp) }
-            coVerify(exactly = 1) { happyInventoryNotifierMock.itemChanged(item3event.item, item3event.eventTimestamp) }
+            coVerify(exactly = 1) { happyInventoryNotifierMock.itemChanged(item1event.item, item1event.eventTimestamp, item1event.id) }
+            coVerify(exactly = 1) { happyInventoryNotifierMock.itemChanged(item2event.item, item2event.eventTimestamp, item2event.id) }
+            coVerify(exactly = 1) { happyInventoryNotifierMock.itemChanged(item3event.item, item3event.eventTimestamp, item3event.id) }
         }
 
     private val testItem = createTestItem()
@@ -164,7 +172,7 @@ class CatalogEventProcessorTest {
 
     private val happyInventoryNotifierMock =
         mockk<InventoryNotifier> {
-            coEvery { itemChanged(any(), any()) } returns Unit
-            coEvery { orderChanged(any(), any()) } returns Unit
+            coEvery { itemChanged(any(), any(), any()) } returns Unit
+            coEvery { orderChanged(any(), any(), any()) } returns Unit
         }
 }

--- a/src/test/kotlin/no/nb/mlt/wls/infrastructure/callbacks/InventoryNotifierAdapterTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/infrastructure/callbacks/InventoryNotifierAdapterTest.kt
@@ -69,8 +69,8 @@ class InventoryNotifierAdapterTest {
 
         testItemWithCallback = createTestItem(callbackUrl = mockServerItemCallbackPath)
         testOrderWithCallback = createTestOrder(callbackUrl = mockServerOrderCallbackPath)
-        itemNotificationPayload = testItemWithCallback.toNotificationItemPayload(timestamp)
-        orderNotificationPayload = testOrderWithCallback.toNotificationOrderPayload(timestamp)
+        itemNotificationPayload = testItemWithCallback.toNotificationItemPayload(timestamp, messageId)
+        orderNotificationPayload = testOrderWithCallback.toNotificationOrderPayload(timestamp, messageId)
 
         inventoryNotifierAdapter = InventoryNotifierAdapter(webClient, proxyWebClient, secretKey, jacksonObjectMapper(), timeoutConfig)
     }
@@ -84,7 +84,7 @@ class InventoryNotifierAdapterTest {
     fun `should send callback on itemChange`() {
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
-        inventoryNotifierAdapter.itemChanged(testItemWithCallback, timestamp)
+        inventoryNotifierAdapter.itemChanged(testItemWithCallback, timestamp, messageId)
         val request = mockWebServer.takeRequest()
 
         assertEquals(itemCallbackPath, request.path)
@@ -99,7 +99,7 @@ class InventoryNotifierAdapterTest {
     fun `should send callback on orderChange`() {
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
-        inventoryNotifierAdapter.orderChanged(testOrderWithCallback, timestamp)
+        inventoryNotifierAdapter.orderChanged(testOrderWithCallback, timestamp, messageId)
         val request = mockWebServer.takeRequest()
 
         assertEquals(orderCallbackPath, request.path)
@@ -116,7 +116,7 @@ class InventoryNotifierAdapterTest {
         val timestamp = Instant.now()
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
-        inventoryNotifierAdapter.itemChanged(item, timestamp)
+        inventoryNotifierAdapter.itemChanged(item, timestamp, messageId)
         val request = mockWebServer.takeRequest()
 
         assertEquals(itemCallbackPath, request.path)
@@ -130,7 +130,7 @@ class InventoryNotifierAdapterTest {
         val order = testOrderWithCallback.copy(hostName = HostName.ASTA)
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
-        inventoryNotifierAdapter.orderChanged(order, timestamp)
+        inventoryNotifierAdapter.orderChanged(order, timestamp, messageId)
         val request = mockWebServer.takeRequest()
 
         assertEquals(orderCallbackPath, request.path)
@@ -143,7 +143,7 @@ class InventoryNotifierAdapterTest {
     fun `should include signature header in item changed callback`() {
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
-        inventoryNotifierAdapter.itemChanged(testItemWithCallback, timestamp)
+        inventoryNotifierAdapter.itemChanged(testItemWithCallback, timestamp, messageId)
         val request = mockWebServer.takeRequest()
 
         val sigHeader = request.getHeader(signatureHeader)
@@ -160,7 +160,7 @@ class InventoryNotifierAdapterTest {
     fun `should include signature header in order changed callback`() {
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
-        inventoryNotifierAdapter.orderChanged(testOrderWithCallback, timestamp)
+        inventoryNotifierAdapter.orderChanged(testOrderWithCallback, timestamp, messageId)
         val request = mockWebServer.takeRequest()
 
         val sigHeader = request.getHeader(signatureHeader)
@@ -184,6 +184,8 @@ class InventoryNotifierAdapterTest {
     private val secretKey = "secretKey"
 
     private val timestamp = Instant.now()
+
+    private val messageId = UUID.randomUUID().toString()
 
     private fun getMac(): Mac {
         val hmacSHA256 = "HmacSHA256"

--- a/src/test/kotlin/no/nb/mlt/wls/item/model/ItemModelConversionTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/item/model/ItemModelConversionTest.kt
@@ -17,6 +17,7 @@ import no.nb.mlt.wls.infrastructure.synq.toSynqPayload
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.util.UUID
 
 class ItemModelConversionTest {
     @Test
@@ -47,7 +48,7 @@ class ItemModelConversionTest {
 
     @Test
     fun `item converts to notification payload`() {
-        val payload = testItem.toNotificationItemPayload(Instant.now())
+        val payload = testItem.toNotificationItemPayload(Instant.now(), UUID.randomUUID().toString())
         assertThat(payload.hostId).isEqualTo(testItemNotificationPayload.hostId)
         assertThat(payload.hostName).isEqualTo(testItemNotificationPayload.hostName)
         assertThat(payload.description).isEqualTo(testItemNotificationPayload.description)
@@ -111,6 +112,7 @@ class ItemModelConversionTest {
             callbackUrl = "https://callback-wls.no/item",
             location = "SYNQ_WAREHOUSE",
             quantity = 1,
-            eventTimestamp = Instant.now()
+            eventTimestamp = Instant.now(),
+            messageId = UUID.randomUUID().toString()
         )
 }

--- a/src/test/kotlin/no/nb/mlt/wls/order/model/OrderModelConversionTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/order/model/OrderModelConversionTest.kt
@@ -20,6 +20,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.time.LocalDateTime
+import java.util.UUID
 
 class OrderModelConversionTest {
     @Test
@@ -76,7 +77,7 @@ class OrderModelConversionTest {
 
     @Test
     fun `order converts to notification payload`() {
-        val testNotificationOrderPayload = testOrder.toNotificationOrderPayload(Instant.now())
+        val testNotificationOrderPayload = testOrder.toNotificationOrderPayload(Instant.now(), UUID.randomUUID().toString())
 
         assertThat(testNotificationOrderPayload.hostName).isEqualTo(testOrderNotification.hostName)
         assertThat(testNotificationOrderPayload.hostOrderId).isEqualTo(testOrderNotification.hostOrderId)
@@ -94,7 +95,7 @@ class OrderModelConversionTest {
         assertThat(order.hostName).isEqualTo(testApiOrderPayload.hostName)
         assertThat(order.hostOrderId).isEqualTo(testApiOrderPayload.hostOrderId)
         assertThat(order.status).isEqualTo(Order.Status.NOT_STARTED)
-        assertThat(order.orderLine).isEqualTo(testApiOrderPayload.orderLine)
+        assertThat(order.orderLine).isEqualTo(testApiOrderPayload.orderLine.map { it -> it.toOrderItem() })
         assertThat(order.orderType).isEqualTo(testApiOrderPayload.orderType)
         assertThat(order.contactPerson).isEqualTo(testApiOrderPayload.contactPerson)
         assertThat(order.address).isEqualTo(testApiOrderPayload.address)
@@ -216,7 +217,8 @@ class OrderModelConversionTest {
             contactEmail = "contact@ema.il",
             note = "note",
             callbackUrl = "https://callback-wls.no/order",
-            eventTimestamp = Instant.now()
+            eventTimestamp = Instant.now(),
+            messageId = UUID.randomUUID().toString()
         )
 
     private val testOrderLine =

--- a/src/test/kotlin/no/nb/mlt/wls/synq/controller/SynqControllerTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/synq/controller/SynqControllerTest.kt
@@ -82,7 +82,7 @@ class SynqControllerTest(
     fun `updateOrder correct payload updates order and sends callback`() =
         runTest {
             every {
-                inventoryNotifierAdapterMock.orderChanged(any(), any())
+                inventoryNotifierAdapterMock.orderChanged(any(), any(), any())
             }.answers { }
 
             webTestClient
@@ -101,14 +101,14 @@ class SynqControllerTest(
             assertThat(res).isNotNull
             assertThat(res.status).isEqualTo(Order.Status.IN_PROGRESS)
 
-            verify { inventoryNotifierAdapterMock.orderChanged(order.copy(status = Order.Status.IN_PROGRESS), any()) }
+            verify { inventoryNotifierAdapterMock.orderChanged(order.copy(status = Order.Status.IN_PROGRESS), any(), any()) }
         }
 
     @Test
     fun `updateOrder short order ID updates order and sends callback`() =
         runTest {
             every {
-                inventoryNotifierAdapterMock.orderChanged(any(), any())
+                inventoryNotifierAdapterMock.orderChanged(any(), any(), any())
             }.answers { }
 
             webTestClient
@@ -127,7 +127,7 @@ class SynqControllerTest(
             assertThat(res).isNotNull
             assertThat(res.status).isEqualTo(Order.Status.IN_PROGRESS)
 
-            verify { inventoryNotifierAdapterMock.orderChanged(order.copy(status = Order.Status.IN_PROGRESS), any()) }
+            verify { inventoryNotifierAdapterMock.orderChanged(order.copy(status = Order.Status.IN_PROGRESS), any(), any()) }
         }
 
     @Test
@@ -213,7 +213,7 @@ class SynqControllerTest(
     fun `moveItem out of AutoStore with correct payload decrements item count`() =
         runTest {
             every {
-                inventoryNotifierAdapterMock.itemChanged(any(), any())
+                inventoryNotifierAdapterMock.itemChanged(any(), any(), any())
             }.answers {}
 
             val item1 = itemRepository.findByHostNameAndHostId(testItem3.hostName, testItem3.hostId).awaitSingle()
@@ -241,7 +241,7 @@ class SynqControllerTest(
     fun `updateItem correct payload updates item and sends callback`() =
         runTest {
             every {
-                inventoryNotifierAdapterMock.itemChanged(any(), any())
+                inventoryNotifierAdapterMock.itemChanged(any(), any(), any())
             }.answers { }
 
             webTestClient
@@ -267,8 +267,8 @@ class SynqControllerTest(
             assertThat(item2.location).isEqualTo(batchMoveItemPayload.location)
             assertThat(item2.quantity).isEqualTo(batchMoveItemPayload.loadUnit[1].quantityOnHand)
 
-            verify { inventoryNotifierAdapterMock.itemChanged(item1.toItem(), any()) }
-            verify { inventoryNotifierAdapterMock.itemChanged(item2.toItem(), any()) }
+            verify { inventoryNotifierAdapterMock.itemChanged(item1.toItem(), any(), any()) }
+            verify { inventoryNotifierAdapterMock.itemChanged(item2.toItem(), any(), any()) }
         }
 
     @Test
@@ -350,7 +350,7 @@ class SynqControllerTest(
     fun `updateItem with no callbackUrl still updates the item`() =
         runTest {
             every {
-                inventoryNotifierAdapterMock.itemChanged(any(), any())
+                inventoryNotifierAdapterMock.itemChanged(any(), any(), any())
             }.answers { }
 
             val testItem = createTestItem(callbackUrl = null, hostId = "test-item")
@@ -373,7 +373,7 @@ class SynqControllerTest(
             assertThat(item.location).isEqualTo(batchMoveItemPayload.location)
             assertThat(item.quantity).isEqualTo(batchMoveItemPayload.loadUnit[0].quantityOnHand)
 
-            verify { inventoryNotifierAdapterMock.itemChanged(item.toItem(), any()) }
+            verify { inventoryNotifierAdapterMock.itemChanged(item.toItem(), any(), any()) }
         }
 
     @Test


### PR DESCRIPTION
Add missing `messageId` field to the callbacks in inventory notifier methods.