### PR TITLE
HOTFIX change timestamp format in statistics messages

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/domain/model/statistics/ItemStatisticsEvent.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/model/statistics/ItemStatisticsEvent.kt
@@ -1,11 +1,14 @@
 package no.nb.mlt.wls.domain.model.statistics
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 import java.time.Instant
 
 data class ItemStatisticsEvent(
     val itemId: String,
     override val eventType: String,
     override val details: Map<String, Any>,
+    @JsonSerialize(using = ToStringSerializer::class)
     override val timestamp: Instant = Instant.now()
 ) : StatisticsEvent {
     override val id: String

--- a/src/main/kotlin/no/nb/mlt/wls/domain/model/statistics/OrderStatisticsEvent.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/model/statistics/OrderStatisticsEvent.kt
@@ -1,11 +1,14 @@
 package no.nb.mlt.wls.domain.model.statistics
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 import java.time.Instant
 
 data class OrderStatisticsEvent(
     val orderId: String,
     override val eventType: String,
     override val details: Map<String, Any>,
+    @JsonSerialize(using = ToStringSerializer::class)
     override val timestamp: Instant = Instant.now()
 ) : StatisticsEvent {
     override val id: String


### PR DESCRIPTION
We found that the old timestamp format was not working well for us in ES, so for clarity we switched them to use ISO date instead