### PR TITLE
MLT-186 Change how Axiell and Mavis are used in SynQ communication

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqBatchMoveItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqBatchMoveItemPayload.kt
@@ -176,7 +176,7 @@ data class Product(
         }
 
         return MoveItemPayload(
-            hostName = HostName.fromString(hostName),
+            hostName = getHostNameFromSynqTypes(),
             hostId = productId,
             quantity = quantity,
             location = location
@@ -185,11 +185,21 @@ data class Product(
 
     fun toUpdateItemPayload(location: String): UpdateItemPayload =
         UpdateItemPayload(
-            hostName = HostName.fromString(hostName),
+            hostName = getHostNameFromSynqTypes(),
             hostId = productId,
             quantity = quantityOnHand ?: throw ItemMovingException("Quantity on hand must not be null"),
             location = location
         )
+
+    private fun getHostNameFromSynqTypes(): HostName {
+        if (hostName.lowercase() == "mavis") {
+            // As of now over 160k items exist with hostName Mavis in SynQ.
+            // These need to be migrated to Axiell, but before that is done we can cheat the system by converting Mavis -> Axiell
+            return HostName.AXIELL
+        }
+
+        return HostName.fromString(hostName)
+    }
 }
 
 @Schema(

--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqController.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqController.kt
@@ -267,7 +267,7 @@ class SynqController(
             return ResponseEntity.badRequest().body("Warehouse cannot be blank")
         }
 
-        val hostName = HostName.fromString(orderUpdatePayload.hostName)
+        val hostName = HostName.fromString(orderUpdatePayload.sanitizedHostName) // Must be changed when we fix SynQ to use Axiel, not Mavis
         orderStatusUpdate.updateOrderStatus(hostName, orderIdWithoutPrefix, orderUpdatePayload.getConvertedStatus())
 
         return ResponseEntity.ok().build()

--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqInventoryReconciliationPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqInventoryReconciliationPayload.kt
@@ -101,10 +101,10 @@ fun LoadUnit.getMappedHostName(): HostName? {
     return when (hostName.lowercase()) {
         "alma" -> HostName.ALMA
         "asta" -> HostName.ASTA
-        "mavis" -> HostName.MAVIS
+        "mavis" -> HostName.AXIELL // This needs to be changed when we have fixed SynQ to use Axiell instead of Mavis
         "axiell" -> HostName.AXIELL
         "mellomlager" -> HostName.TEMP_STORAGE
-        else -> null
+        else -> null // @Tom shouldn't this be HostName.NONE or at least a ValidationException?
     }
 }
 

--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqOrderPickingConfirmationPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqOrderPickingConfirmationPayload.kt
@@ -61,6 +61,12 @@ data class SynqOrderPickingConfirmationPayload(
     fun getValidHostName(): HostName {
         val hostName = getHostNameString()
         try {
+            if (hostName.lowercase() == "mavis") {
+                // As of now over 160k items exist with hostName Mavis in SynQ.
+                // These need to be migrated to Axiell, but before that is done we can cheat the system by converting Mavis -> Axiell
+                return HostName.AXIELL
+            }
+
             return HostName.fromString(hostName)
         } catch (e: IllegalArgumentException) {
             throw ValidationException("Hostname $hostName is not recognized by WLS", e)

--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqOrderStatusUpdatePayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqOrderStatusUpdatePayload.kt
@@ -38,6 +38,15 @@ data class SynqOrderStatusUpdatePayload(
     val warehouse: String
 )
 
+val SynqOrderStatusUpdatePayload.sanitizedHostName: String
+    get() {
+        if (hostName.lowercase() == "mavis") {
+            return "AXIELL"
+        }
+
+        return hostName
+    }
+
 enum class SynqOrderStatus {
     ALLOCATED,
     ALLOCATING,

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqProductPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/synq/SynqProductPayload.kt
@@ -70,7 +70,7 @@ fun toSynqHostname(hostName: HostName): String =
         HostName.ALMA -> "Alma"
         HostName.ASTA -> "Asta"
         HostName.MAVIS -> "Mavis"
-        HostName.AXIELL -> "Axiell"
+        HostName.AXIELL -> "Mavis" // This needs to be changed when we have fixed SynQ to use Axiell instead of Mavis
         HostName.TEMP_STORAGE -> "mellomlager"
         HostName.NONE -> throw NotImplementedError("Creating Products for HostName.NONE is not supported")
     }


### PR DESCRIPTION
SynQ has over 180k products with hostName Mavis. Mavis is dead now, and Axiell took over. However, all those objects are still owned by Mavis in SynQ. As changing the data in SynQ might be risky and take time we will instead change SynQ adapter code to convert Axiell → Mavis on the way into SynQ and vice versa. It also requires us to update our internal database, much easier and more manageable, to use Axiell instead of Mavis so duplicate check on the way into Hermes will work correctly, as well as help with orders and shiii…

- Update Hermes adapter to handle Mavis ↔︎ Axiell conversion
- SynQ Gateway forwards Mavis communication to us (should already happen, but doesn’t hurt to check
- Database update script for converting Mavis → Axiell must be prepared and tested in stage

This PR solves first part of the task, from what I see part two is already done and functional, all that remains after that is to find how we want to update the database.

