### PR TITLE
MLT-0214 Ignore SynQ status updates which complete orders

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqController.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqController.kt
@@ -267,6 +267,11 @@ class SynqController(
             return ResponseEntity.badRequest().body("Warehouse cannot be blank")
         }
 
+        if (orderUpdatePayload.status == SynqOrderStatus.COMPLETED) {
+            // no-op
+            return ResponseEntity.ok().build()
+        }
+
         val hostName = HostName.fromString(orderUpdatePayload.sanitizedHostName) // Must be changed when we fix SynQ to use Axiel, not Mavis
         updateOrderStatus.updateOrderStatus(hostName, orderIdWithoutPrefix, orderUpdatePayload.getConvertedStatus())
 

--- a/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqOrderStatusUpdatePayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/synqapi/synq/SynqOrderStatusUpdatePayload.kt
@@ -3,6 +3,7 @@ package no.nb.mlt.wls.application.synqapi.synq
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import no.nb.mlt.wls.domain.model.Order
+import no.nb.mlt.wls.domain.ports.inbound.IllegalOrderStateException
 
 @Schema(
     description = """Payload with updated status information for an order placed in SynQ.""",
@@ -66,7 +67,7 @@ enum class SynqOrderStatus {
 fun SynqOrderStatusUpdatePayload.getConvertedStatus() =
     when (status) {
         SynqOrderStatus.NEW -> Order.Status.NOT_STARTED
-        SynqOrderStatus.COMPLETED -> Order.Status.COMPLETED
+        SynqOrderStatus.COMPLETED -> throw IllegalOrderStateException("SynQ is not allowed to decide if the order is complete")
         SynqOrderStatus.CANCELLED -> Order.Status.DELETED
         else -> Order.Status.IN_PROGRESS
     }

--- a/src/test/kotlin/no/nb/mlt/wls/synq/model/SynqModelConversionTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/synq/model/SynqModelConversionTest.kt
@@ -7,11 +7,13 @@ import no.nb.mlt.wls.application.synqapi.synq.getConvertedStatus
 import no.nb.mlt.wls.createTestItem
 import no.nb.mlt.wls.domain.model.HostName
 import no.nb.mlt.wls.domain.model.Order
+import no.nb.mlt.wls.domain.ports.inbound.IllegalOrderStateException
 import no.nb.mlt.wls.infrastructure.synq.toSynqHostname
 import no.nb.mlt.wls.toMovedProduct
 import no.nb.mlt.wls.toProduct
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class SynqModelConversionTest {
     @Test
@@ -23,10 +25,10 @@ class SynqModelConversionTest {
         val released = synqOrderStatusUpdatePayload.copy(status = SynqOrderStatus.RELEASED)
 
         assertThat(notStarted.getConvertedStatus()).isEqualTo(Order.Status.NOT_STARTED)
-        assertThat(completed.getConvertedStatus()).isEqualTo(Order.Status.COMPLETED)
         assertThat(cancelled.getConvertedStatus()).isEqualTo(Order.Status.DELETED)
         assertThat(allocated.getConvertedStatus()).isEqualTo(Order.Status.IN_PROGRESS)
         assertThat(released.getConvertedStatus()).isEqualTo(Order.Status.IN_PROGRESS)
+        assertThrows<IllegalOrderStateException> { completed.getConvertedStatus() }
     }
 
     @Test


### PR DESCRIPTION
This usually leads the order into an invalid state, as it marks it as complete despite the other order lines not being picked.