### PR TITLE
MLT-0207 - Remove throws annotation for GetOrder

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/GetOrder.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/ports/inbound/GetOrder.kt
@@ -2,7 +2,6 @@ package no.nb.mlt.wls.domain.ports.inbound
 
 import no.nb.mlt.wls.domain.model.HostName
 import no.nb.mlt.wls.domain.model.Order
-import no.nb.mlt.wls.domain.ports.inbound.exceptions.OrderNotFoundException
 
 /**
  * A port for retrieving an order based on a given host name and order ID.
@@ -12,7 +11,6 @@ import no.nb.mlt.wls.domain.ports.inbound.exceptions.OrderNotFoundException
  * @see Order
  */
 fun interface GetOrder {
-    @Throws(OrderNotFoundException::class)
     suspend fun getOrder(
         hostName: HostName,
         hostOrderId: String


### PR DESCRIPTION
The annotation is inaccurate, as this function does not throw this by itself. This and GetItem behave exactly the same. 