### PR TITLE
MLT-220 Fix QR code embedding in emails

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/email/EmailAdapter.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/email/EmailAdapter.kt
@@ -85,7 +85,7 @@ class EmailAdapter(
         val receiver = order.contactEmail
         if (receiver.isNullOrBlank()) {
             logger.warn {
-                "No contact email was present for ${order.hostOrderId}, so and email was not sent"
+                "No contact email was present for ${order.hostOrderId}, so an email was not sent"
             }
             return null
         }
@@ -161,7 +161,7 @@ class EmailAdapter(
     ): MimeBodyPart {
         val imagePart = MimeBodyPart()
         imagePart.disposition = MimeBodyPart.INLINE
-        imagePart.contentID = "qr-$cid"
+        imagePart.contentID = "qr-${sanitizeID(cid)}"
         imagePart.dataHandler = BarcodeUtils.createImageDataHandler(image)
         return imagePart
     }
@@ -176,8 +176,10 @@ class EmailAdapter(
 
     private fun getQrHtmlString(cid: String): String =
         """
-            <img src="cid:qr-$cid" alt="qrcode of '$cid'"/></img>
+            <img src="cid:qr-${sanitizeID(cid)}" alt="qrcode of '$cid'"/></img>
         """
+
+    private fun sanitizeID(id: String): String = id.replace(Regex("[\\s<>\"'&]"), "_")
 
     data class EmailOrderItem(
         val item: Item,

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/email/EmailAdapter.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/email/EmailAdapter.kt
@@ -85,7 +85,7 @@ class EmailAdapter(
         val receiver = order.contactEmail
         if (receiver.isNullOrBlank()) {
             logger.warn {
-                "No contact email was present for ${order.hostOrderId}, so an email was not sent"
+                "No contact email is present for ${order.hostOrderId}, so the confirmation email can't be sent"
             }
             return null
         }

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/email/EmailAdapter.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/email/EmailAdapter.kt
@@ -85,7 +85,7 @@ class EmailAdapter(
         val receiver = order.contactEmail
         if (receiver.isNullOrBlank()) {
             logger.warn {
-                "No contact email is present for ${order.hostOrderId}, so the confirmation email can't be sent"
+                "Contact email is not present for order ${order.hostOrderId}, so the confirmation email can't be sent"
             }
             return null
         }

--- a/src/main/resources/templates/email/order.ftl
+++ b/src/main/resources/templates/email/order.ftl
@@ -63,7 +63,7 @@
                         <div>
                             ${orderItem.qr}
                         </div>
-                        ${orderItem.item.hostId}
+                        <pre>${orderItem.item.hostId}</pre>
                     </td>
                     <td>${orderItem.item.location}</td>
                 </tr>


### PR DESCRIPTION
In cases where item ID contains spaces the `img` tag would have a mangled `src` attribute. ID will now be sanitized for illegal characters. As Noah pointed out alternative solution would involve using a counter.