### PR TITLE
Update logging again

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/event/MongoCatalogEventRepositoryAdapter.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/event/MongoCatalogEventRepositoryAdapter.kt
@@ -26,11 +26,15 @@ class MongoCatalogEventRepositoryAdapter(
     override suspend fun save(event: CatalogEvent): CatalogEvent =
         mongoCatalogMessageRepository
             .save(MongoCatalogEvent(body = event))
-            .map { it.body }
-            .doOnEach { signal ->
+            .map {
+                logger.info {
+                    "Processing storage event to outbox: ${it.body}"
+                }
+                it.body
+            }.doOnEach { signal ->
                 if (signal.isOnComplete) {
                     logger.info {
-                        "Saved catalog event to catalog outbox: ${signal.get()}"
+                        "Successfully saved catalog event to catalog outbox"
                     }
                 }
             }.timeout(timeoutConfig.mongo)

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/event/MongoStorageEventRepositoryAdapter.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/repositories/event/MongoStorageEventRepositoryAdapter.kt
@@ -26,11 +26,15 @@ class MongoStorageEventRepositoryAdapter(
     override suspend fun save(event: StorageEvent): StorageEvent =
         mongoStorageEventRepository
             .save(MongoStorageEvent(body = event))
-            .map { it.body }
-            .doOnEach { signal ->
+            .map {
+                logger.info {
+                    "Processing storage event to outbox: ${it.body}"
+                }
+                it.body
+            }.doOnEach { signal ->
                 if (signal.isOnComplete) {
                     logger.info {
-                        "Saved storage event to outbox: ${signal.get()}"
+                        "Successfully saved storage event to storage outbox"
                     }
                 }
             }.timeout(timeoutConfig.mongo)


### PR DESCRIPTION
Fixed it for real this time.

Misread the type of `Signal<StorageEvent!>!` as a guarantee that the value would not be null. Turns out it is null when the signal is complete, as it is done processing everything.
This changes the logging to note what event it is working on during mapping, to then later confirm whether the processing was successful. 

An example of the new structure seen in logs:

```
// Example on success
2025-09-24T09:15:09.353+02:00  INFO 52674 --- [Hermes] [ntLoopGroup-3-6] [] i.r.e.MongoStorageEventRepositoryAdapter : Processing storage event to outbox: OrderCreated(createdOrder=Order(hostName=AXIELL, hostOrderId=testOrder-01, status=NOT_STARTED, orderLine=[OrderItem(hostId=testItem-01, status=NOT_STARTED), OrderItem(hostId=testItem-02, status=NOT_STARTED)], orderType=LOAN, address=Address(recipient=recipient, addressLine1=addressLine1, addressLine2=addressLine2, postcode=postcode, city=city, region=region, country=country), contactPerson=contactPerson, contactEmail=contact@ema.il, note=note, callbackUrl=https://callback-wls.no/order), id=41873a87-5205-485c-bcbc-e7100d1b97d9)
2025-09-24T09:15:09.353+02:00  INFO 52674 --- [Hermes] [ntLoopGroup-3-6] [] i.r.e.MongoStorageEventRepositoryAdapter : Successfully saved storage event to storage outbox
// Example on fail
2025-09-24T09:08:57.116+02:00  INFO 50791 --- [Hermes] [ntLoopGroup-3-7] [] i.r.e.MongoStorageEventRepositoryAdapter : Processing storage event to outbox: OrderCreated(createdOrder=Order(hostName=AXIELL, hostOrderId=testOrder-01, status=NOT_STARTED, orderLine=[OrderItem(hostId=testItem-01, status=NOT_STARTED), OrderItem(hostId=testItem-02, status=NOT_STARTED)], orderType=LOAN, address=Address(recipient=recipient, addressLine1=addressLine1, addressLine2=addressLine2, postcode=postcode, city=city, region=region, country=country), contactPerson=contactPerson, contactEmail=contact@ema.il, note=note, callbackUrl=https://callback-wls.no/order), id=ad693744-2979-4369-b24b-302e91de82bd)
2025-09-24T09:08:57.116+02:00 ERROR 50791 --- [Hermes] [ntLoopGroup-3-7] [] i.r.e.MongoStorageEventRepositoryAdapter : Timed out while saving event to storage outbox. Event: OrderCreated(createdOrder=Order(hostName=AXIELL, hostOrderId=testOrder-01, status=NOT_STARTED, orderLine=[OrderItem(hostId=testItem-01, status=NOT_STARTED), OrderItem(hostId=testItem-02, status=NOT_STARTED)], orderType=LOAN, address=Address(recipient=recipient, addressLine1=addressLine1, addressLine2=addressLine2, postcode=postcode, city=city, region=region, country=country), contactPerson=contactPerson, contactEmail=contact@ema.il, note=note, callbackUrl=https://callback-wls.no/order), id=ad693744-2979-4369-b24b-302e91de82bd)
``` 