### PR TITLE
MLT-235 Send order emails as the contact person if possible

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/email/EmailAdapter.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/email/EmailAdapter.kt
@@ -144,7 +144,7 @@ class EmailAdapter(
             )
         helper.setText(htmlBody, true)
         helper.setSubject("Ny bestilling fra ${order.hostName} - ${order.hostOrderId}")
-        helper.setFrom(senderEmail)
+        helper.setFrom(order.contactEmail?.ifBlank { null } ?: senderEmail)
         helper.setTo(storageEmail)
         // QR-Code image handling for order ID and order items
         val orderIdQrImage = BarcodeUtils.createQrImage(order.hostOrderId, scale = 3, border = 4)


### PR DESCRIPTION
Send order email to Magasintjenesten as the contact person if possible. Better usability for both users and operators as users get confirmation and update emails directly, and operators have direct contact to users