### PR TITLE
MLT-331 Fix WITH_LENDER location name

### DIFF
--- a/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/hostapi/item/ApiItemPayload.kt
@@ -75,7 +75,7 @@ data class ApiItemPayload(
     @field:Schema(
         description = """Last known storage location of the item.
             Can be used for tracking item movement through storage systems.""",
-        examples = ["UNKNOWN", "WITH_LENDER", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"]
+        examples = ["UNKNOWN", "ON_LOAN", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"]
     )
     val location: String,
     @field:Schema(

--- a/src/main/kotlin/no/nb/mlt/wls/application/logisticsapi/ApiDetailedOrder.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/logisticsapi/ApiDetailedOrder.kt
@@ -198,7 +198,7 @@ data class DetailedOrderItem(
     @field:Schema(
         description = """Last known storage location of the item.
             Can be used for tracking item movement through storage systems.""",
-        examples = ["UNKNOWN", "WITH_LENDER", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"]
+        examples = ["UNKNOWN", "ON_LOAN", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"]
     )
     val location: String,
     @field:Schema(

--- a/src/main/kotlin/no/nb/mlt/wls/application/logisticsapi/ApiItem.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/application/logisticsapi/ApiItem.kt
@@ -51,7 +51,7 @@ data class ApiItem(
     @field:Schema(
         description = """Last known storage location of the item.
             Can be used for tracking item movement through storage systems.""",
-        examples = ["UNKNOWN", "WITH_LENDER", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"]
+        examples = ["UNKNOWN", "ON_LOAN", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"]
     )
     val location: String,
     @field:Schema(

--- a/src/main/kotlin/no/nb/mlt/wls/domain/model/Item.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/model/Item.kt
@@ -6,10 +6,10 @@ import no.nb.mlt.wls.domain.ports.inbound.exceptions.ValidationException
 private val logger = KotlinLogging.logger {}
 
 /**
- * Marks the location of an item that is with a lender.
+ * Marks the location of an item that is on loan with a borrower.
  * Ensures we use the same value across the application to avoid confusion.
  */
-const val WITH_LENDER_LOCATION = "WITH_LENDER"
+const val ON_LOAN_LOCATION = "ON_LOAN"
 
 /**
  * Marks the location of an item when we don't know where it is.
@@ -65,7 +65,7 @@ data class Item(
      * Picks a specified amount of items from the stock.
      * If the amount picked exceeds the available quantity, it logs an error and sets the quantity
      * to zero, indicating that the item is no longer available.
-     * If after picking the quantity becomes zero, it sets the location to [WITH_LENDER_LOCATION].
+     * If after picking the quantity becomes zero, it sets the location to [ON_LOAN_LOCATION].
      *
      * @param amountPicked The number of items to pick from the stock.
      * @return The updated Item instance with the new quantity.
@@ -85,7 +85,7 @@ data class Item(
 
         val quantity = Math.clamp(itemsInStockQuantity.minus(amountPicked).toLong(), 0, Int.MAX_VALUE)
         if (quantity == 0) {
-            location = WITH_LENDER_LOCATION
+            location = ON_LOAN_LOCATION
         }
 
         return this.copy(
@@ -103,7 +103,7 @@ data class Item(
      * Constraints:
      * - If [quantity] is not zero, then the [location] can not be null.
      * - Updates from other storage systems are ignored if the quantity is zero.
-     * - Updates where [location] is null and current location is [WITH_LENDER_LOCATION] will be ignored.
+     * - Updates where [location] is null and current location is [ON_LOAN_LOCATION] will be ignored.
      *
      * @param quantity The new quantity to set for the item.
      * @param location The new location to set for the item.
@@ -125,8 +125,8 @@ data class Item(
             throw ValidationException("Location must be set when quantity is not zero")
         }
 
-        // do not override with lender location
-        if (location == null && this.location == WITH_LENDER_LOCATION) {
+        // do not override with on loan location
+        if (location == null && this.location == ON_LOAN_LOCATION) {
             return this
         }
 

--- a/src/main/kotlin/no/nb/mlt/wls/domain/model/Item.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/domain/model/Item.kt
@@ -6,7 +6,7 @@ import no.nb.mlt.wls.domain.ports.inbound.exceptions.ValidationException
 private val logger = KotlinLogging.logger {}
 
 /**
- * Marks the location of an item that is on loan with a borrower.
+ * Marks the location of an item that is on loan to a borrower.
  * Ensures we use the same value across the application to avoid confusion.
  */
 const val ON_LOAN_LOCATION = "ON_LOAN"

--- a/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/NotificationItemPayload.kt
+++ b/src/main/kotlin/no/nb/mlt/wls/infrastructure/callbacks/NotificationItemPayload.kt
@@ -79,7 +79,7 @@ data class NotificationItemPayload(
     @field:Schema(
         description = """Last known storage location of the item.
             Can be used for tracking item movement through storage systems.""",
-        examples = ["UNKNOWN", "WITH_LENDER", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"]
+        examples = ["UNKNOWN", "ON_LOAN", "SYNQ_WAREHOUSE", "AUTOSTORE", "KARDEX"]
     )
     val location: String,
     @field:Schema(

--- a/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
@@ -13,10 +13,10 @@ import no.nb.mlt.wls.domain.model.Environment
 import no.nb.mlt.wls.domain.model.HostName
 import no.nb.mlt.wls.domain.model.Item
 import no.nb.mlt.wls.domain.model.ItemCategory
+import no.nb.mlt.wls.domain.model.ON_LOAN_LOCATION
 import no.nb.mlt.wls.domain.model.Order
 import no.nb.mlt.wls.domain.model.Packaging
 import no.nb.mlt.wls.domain.model.UNKNOWN_LOCATION
-import no.nb.mlt.wls.domain.model.ON_LOAN_LOCATION
 import no.nb.mlt.wls.domain.model.events.catalog.CatalogEvent
 import no.nb.mlt.wls.domain.model.events.catalog.ItemEvent
 import no.nb.mlt.wls.domain.model.events.catalog.OrderEvent

--- a/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
+++ b/src/test/kotlin/no/nb/mlt/wls/domain/WLSServiceTest.kt
@@ -16,7 +16,7 @@ import no.nb.mlt.wls.domain.model.ItemCategory
 import no.nb.mlt.wls.domain.model.Order
 import no.nb.mlt.wls.domain.model.Packaging
 import no.nb.mlt.wls.domain.model.UNKNOWN_LOCATION
-import no.nb.mlt.wls.domain.model.WITH_LENDER_LOCATION
+import no.nb.mlt.wls.domain.model.ON_LOAN_LOCATION
 import no.nb.mlt.wls.domain.model.events.catalog.CatalogEvent
 import no.nb.mlt.wls.domain.model.events.catalog.ItemEvent
 import no.nb.mlt.wls.domain.model.events.catalog.OrderEvent
@@ -209,7 +209,7 @@ class WLSServiceTest {
             createTestItem(
                 hostName = startingItem.hostName,
                 hostId = startingItem.hostId,
-                location = WITH_LENDER_LOCATION,
+                location = ON_LOAN_LOCATION,
                 associatedStorage = AssociatedStorage.SYNQ,
                 quantity = 0
             )
@@ -241,7 +241,7 @@ class WLSServiceTest {
     @Test
     fun `moveItem should change item's location and quantity`() {
         val startingItem = createTestItem(location = "SYNQ_WAREHOUSE", quantity = 1, associatedStorage = AssociatedStorage.SYNQ)
-        val expectedItem = startingItem.copy(location = WITH_LENDER_LOCATION, quantity = 0)
+        val expectedItem = startingItem.copy(location = ON_LOAN_LOCATION, quantity = 0)
         val moveItemPayload = MoveItemPayload(expectedItem.hostName, expectedItem.hostId, -1, expectedItem.location, expectedItem.associatedStorage)
         val itemMovedEvent = ItemEvent(expectedItem)
 
@@ -276,7 +276,7 @@ class WLSServiceTest {
 
     @Test
     fun `pickItems should update items and send callbacks`() {
-        val expectedItem = createTestItem(quantity = 0, location = WITH_LENDER_LOCATION)
+        val expectedItem = createTestItem(quantity = 0, location = ON_LOAN_LOCATION)
         val pickedItemsMap = mapOf(expectedItem.hostId to 1)
         val itemPickedEvent = ItemEvent(expectedItem)
 
@@ -662,7 +662,7 @@ class WLSServiceTest {
 
     @Test
     fun `pickOrderItems with duplicate lines should only generate one event`() {
-        val pickedItem = createTestItem(location = WITH_LENDER_LOCATION, quantity = 0)
+        val pickedItem = createTestItem(location = ON_LOAN_LOCATION, quantity = 0)
         val order =
             createTestOrder(
                 orderLine =
@@ -714,7 +714,7 @@ class WLSServiceTest {
         val item1 = createTestItem()
         val item2 = createTestItem(hostId = "testItem-02")
         val itemsToPick = listOf(item1.hostId)
-        val pickedItem = createTestItem(location = WITH_LENDER_LOCATION, quantity = 0)
+        val pickedItem = createTestItem(location = ON_LOAN_LOCATION, quantity = 0)
         val order =
             createTestOrder(
                 orderLine =


### PR DESCRIPTION
Change "WITH_LENDER" to be "ON_LOAN" so it better reflects actual item location

When deploying run:

```
use wls

db.items.countDocuments({ location: "WITH_LENDER" })

db.items.updateMany(
  { location: "WITH_LENDER" },
  { $set: { location: "ON_LOAN" } }
)

db.items.countDocuments({ location: "ON_LOAN" })
```